### PR TITLE
ssl_verification must be a str

### DIFF
--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -28,7 +28,7 @@ def get_prepared_config(
     :param profile: aws cli profile
     """
     adfs_config.profile = profile
-    adfs_config.ssl_verification = ssl_verification
+    adfs_config.ssl_verification = str(ssl_verification)
     adfs_config.region = region
     adfs_config.adfs_host = adfs_host
     adfs_config.output_format = output_format


### PR DESCRIPTION
Needs to be a string since we call ast.parse_literal on it, but the
Click option is a switch, which results in a bool. Convert it to str
when storing.