### PR TITLE
Move pytest-runner out of setup-requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ else:
     raise RuntimeError("Unable to find version string in %s." % (VERSIONFILE,))
 
 tests_require = [
+    'pytest-runner',
     'pytest',
     'mock',
     'coverage < 4'
@@ -63,7 +64,6 @@ setup(
         'Programming Language :: Python',
     ],
     setup_requires=[
-        'pytest-runner',
         'setuptools',
     ],
     install_requires=install_requires,


### PR DESCRIPTION
Setup should not require pytest-runner, just tests. Fixes pip not properly cataloguing install requirements based on information available from pypi.