### PR TITLE
Added extra option "--provider-id" 

### DIFF
--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -8,6 +8,7 @@ def authenticate(config, username=None, password=None):
         adfs_host=config.adfs_host,
         adfs_cookie_location=config.adfs_cookie_location,
         ssl_verification_enabled=config.ssl_verification,
+        provider_id=config.provider_id,
         username=username,
         password=password,
     )

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -23,10 +23,10 @@ except ImportError:
     pass
 
 # The initial URL that starts the authentication process.
-_IDP_ENTRY_URL = 'https://{}/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices'
+_IDP_ENTRY_URL = 'https://{}/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp={}'
 
 
-def fetch_html_encoded_roles(adfs_host, adfs_cookie_location, ssl_verification_enabled, username=None, password=None):
+def fetch_html_encoded_roles(adfs_host, adfs_cookie_location, ssl_verification_enabled, provider_id, username=None, password=None):
     # Initiate session handler
     session = requests.Session()
     session.cookies = cookielib.LWPCookieJar(filename=adfs_cookie_location)
@@ -43,7 +43,7 @@ def fetch_html_encoded_roles(adfs_host, adfs_cookie_location, ssl_verification_e
         )
 
     # Opens the initial AD FS URL and follows all of the HTTP302 redirects
-    authentication_url = _IDP_ENTRY_URL.format(adfs_host)
+    authentication_url = _IDP_ENTRY_URL.format(adfs_host, provider_id)
     response = session.post(
         authentication_url,
         verify=ssl_verification_enabled,
@@ -52,7 +52,7 @@ def fetch_html_encoded_roles(adfs_host, adfs_cookie_location, ssl_verification_e
         data={
             'UserName': username,
             'Password': password,
-            'AuthMethod': 'urn:amazon:webservices'
+            'AuthMethod': provider_id
         }
     )
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -42,17 +42,23 @@ from .prepare import adfs_config
     type=click.Choice(['json', 'text', 'table']),
     help='Output format used by aws cli',
 )
+@click.option(
+    '--provider-id',
+    default=lambda: adfs_config.provider_id,
+    help='Provider ID, e.g urn:amazon:webservices (optional)',
+)
 def login(
         profile,
         region,
         ssl_verification,
         adfs_host,
         output_format,
+        provider_id,
 ):
     """
     Authenticates an user with active directory credentials
     """
-    config = prepare.get_prepared_config(profile, region, ssl_verification, adfs_host, output_format)
+    config = prepare.get_prepared_config(profile, region, ssl_verification, adfs_host, output_format, provider_id)
 
     _verification_checks(config)
 

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -11,6 +11,7 @@ def get_prepared_config(
         ssl_verification,
         adfs_host,
         output_format,
+        provider_id,
 ):
     """
     Prepares ADF configuration for login task.
@@ -32,6 +33,7 @@ def get_prepared_config(
     adfs_config.region = region
     adfs_config.adfs_host = adfs_host
     adfs_config.output_format = output_format
+    adfs_config.provider_id = provider_id
     _create_base_aws_cli_config_files_if_needed(adfs_config)
     _load_adfs_config_from_stored_profile(adfs_config, profile)
 
@@ -73,6 +75,9 @@ def _create_adfs_default_config():
     config.adfs_host = None
 
     config.adfs_user = None
+
+    # aws provider id. (Optional - 9/10 times it will always be urn:amazon:websevices)
+    config.provider_id = session.profile or 'urn:amazon:webservices'
 
     return config
 

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -18,6 +18,7 @@ class TestConfigPreparation:
         default_region = 'default_region'
         default_adfs_host = 'default_adfs_host'
         default_output_format = 'default_output_format'
+        default_provider_id = 'default_provider_id'
 
         # when configuration is prepared for not existing profile
         adfs_config = prepare.get_prepared_config(
@@ -26,6 +27,7 @@ class TestConfigPreparation:
             default_ssl_config,
             default_adfs_host,
             default_output_format,
+            default_provider_id,
         )
 
         # then resolved config contains defaults values
@@ -50,6 +52,7 @@ class TestConfigPreparation:
         irrelevant_region = 'irrelevant_region'
         irrelevant_adfs_host = 'irrelevant_adfs_host'
         irrelevant_output_format = 'irrelevant_output_format'
+        irrelevant_provider_id = 'irrelevant_provider_id'
 
         # when configuration is prepared for existing profile
         adfs_config = prepare.get_prepared_config(
@@ -58,6 +61,7 @@ class TestConfigPreparation:
             default_ssl_config,
             irrelevant_adfs_host,
             irrelevant_output_format,
+            irrelevant_provider_id,
         )
 
         # then resolved ssl verification holds the default value

--- a/test/test_fetch_html_encoded_roles.py
+++ b/test/test_fetch_html_encoded_roles.py
@@ -31,11 +31,15 @@ class TestFetchHtmlEncodedRoles:
         # and credentials are not provided
         no_credentials_provided = None
 
+        # and provider_id are not provided
+        no_provider_id_provided = None
+
         # when a call against adfs host is performed
         html = html_roles_fetcher.fetch_html_encoded_roles(
             adfs_host=adfs_host,
             adfs_cookie_location=there_is_no_cookie_on_the_location,
             ssl_verification_enabled=ssl_verification_is_irrelevant,
+            provider_id=no_provider_id_provided,
             username=no_credentials_provided,
             password=no_credentials_provided,
         )
@@ -47,6 +51,7 @@ class TestFetchHtmlEncodedRoles:
     def test_always_use_en_on_accept_language(self):
         # given adfs host which doesn't care that ssl is enabled or not
         adfs_host = 'adfs.awsome.com'
+        provider_id = None
         ssl_verification_is_irrelevant = False
 
         requests = html_roles_fetcher.requests = mock.Mock()
@@ -73,25 +78,29 @@ class TestFetchHtmlEncodedRoles:
         # and authentication provider is irrelevant (adfs or windws sspi)
         authenticator_is_irrelevant = None
 
+        # and provider_id are not provided
+        no_provider_id_provided = None
+
         # when a call against adfs host is performed
         html = html_roles_fetcher.fetch_html_encoded_roles(
             adfs_host=adfs_host,
             adfs_cookie_location=there_is_no_cookie_on_the_location,
             ssl_verification_enabled=ssl_verification_is_irrelevant,
+            provider_id=no_provider_id_provided,
             username=no_credentials_provided,
             password=no_credentials_provided,
         )
 
         # then en was requested as preferred language
         new_session.post.assert_called_with(
-            html_roles_fetcher._IDP_ENTRY_URL.format(adfs_host),
+            html_roles_fetcher._IDP_ENTRY_URL.format(adfs_host, provider_id),
             verify=ssl_verification_is_irrelevant,
             auth=authenticator_is_irrelevant,
             headers={'Accept-Language': 'en'},
             data={
                 'UserName': no_credentials_provided,
                 'Password': no_credentials_provided,
-                'AuthMethod': 'urn:amazon:webservices'
+                'AuthMethod': provider_id
             }
         )
 


### PR DESCRIPTION
As per issue #18 - this is the kind of work around I require. My parent company provide the SSO for all its child companies, and as a result, the urn is different for each. Not sure if this is the correct way for them to do this, but it is. So it required me to edit he hard coded value in the library.