### PR TITLE
#20 - add additional information in list command's output

### DIFF
--- a/aws_adfs/list_profiles.py
+++ b/aws_adfs/list_profiles.py
@@ -15,9 +15,13 @@ def list_profiles():
     config.read(adfs_config.aws_credentials_location)
 
     profiles = config.sections()
+
+    config.read(adfs_config.aws_config_location)
+
     if len(profiles) < 1:
         click.echo('No defined profiles')
     else:
         click.echo('Available profiles:')
         for profile in profiles:
-            click.echo('    * {}'.format(profile))
+            role_arn = config.get(profile,'adfs_config.role_arn')
+            click.echo(' * {} | {}'.format(profile, role_arn))


### PR DESCRIPTION
-  additional information in list command

Before:

```
$ aws-adfs list
Available profiles:
    * default 
```

After:

```
$ aws-adfs list
Available profiles:
    * default | arn:aws:iam::xxxxxxxx:role/adfs-admin
```