### PR TITLE
Fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ aws-adfs integrates with:
       --s3-signature-version [s3v4]   s3 signature version: Identifies the version
                                       of AWS Signature to support for
                                       authenticated requests. Valid values: s3v4
-      --help                          Show this message and exit.    ```
+      --help                          Show this message and exit.
 
+    ```
     ```
     $ aws-adfs reset --help                                                                                                                                              13:39
     Usage: aws-adfs reset [OPTIONS]


### PR DESCRIPTION
backticks around the `aws-adfs reset` block were out of kilter. Fixed so they wrap the reset block correctly