### PR TITLE
wip - configurable sts token time to live

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -50,7 +50,7 @@ from .prepare import adfs_config
 )
 @click.option(
     '--sts-ttl',
-    default=32400,
+    default=9,
     help='The time in hours for the STS token duration.',
 )
 def login(

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -48,6 +48,11 @@ from .prepare import adfs_config
     help='s3 signature version: Identifies the version of AWS Signature to support for '
          'authenticated requests. Valid values: s3v4',
 )
+@click.option(
+    '--sts-ttl',
+    default=32400,
+    help='The time in hours for the STS token duration.',
+)
 def login(
         profile,
         region,
@@ -113,7 +118,7 @@ def login(
         RoleArn=config.role_arn,
         PrincipalArn=principal_arn,
         SAMLAssertion=assertion,
-        DurationSeconds=3600,
+        DurationSeconds=3600 * sts-ttl,
     )
 
     _store(config, aws_session_token)


### PR DESCRIPTION
I have never used click. Not sure if this is more than a conversation starter. We use aws-adfs at BYU and would like to be able to get longer lived tokens from STS. This PR attempts to make the DurationSeconds configurable.

- sets sts duration as parameter
- sets default value to 9 hours 
- converts value to seconds for boto.
