### PR TITLE
#42 - Bug in parsing Duo host and signature, backwards compatible

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -1,5 +1,6 @@
 import click
 import lxml.etree as ET
+from pprint import pprint
 
 import logging
 import re
@@ -357,20 +358,27 @@ _duo_host_pattern = re.compile("'host': '([^']+)'")
 
 
 def _duo_host(html_response):
-    duo_host_query = './/form[@id="duo_form"]/following-sibling::script'
-    element = html_response.xpath(duo_host_query)[0]
-    m = _duo_host_pattern.search(element.text)
-    return m.group(1)
-
+    try:
+        duo_host_query = './/form[@id="duo_form"]/following-sibling::script'
+        element = html_response.xpath(duo_host_query)[0]
+        m = _duo_host_pattern.search(element.text)
+        return m.group(1)
+    except:
+        duo_host_query = './/input[@name="duo_host"]/@value'
+        return html_response.xpath(duo_host_query)[0]
 
 _duo_signature_pattern = re.compile("'sig_request': '([^']+)'")
 
 
 def _duo_request_signature(html_response):
-    duo_signature_query = './/form[@id="duo_form"]/following-sibling::script'
-    element = html_response.xpath(duo_signature_query)[0]
-    m = _duo_signature_pattern.search(element.text)
-    return m.group(1)
+    try:
+        duo_signature_query = './/form[@id="duo_form"]/following-sibling::script'
+        element = html_response.xpath(duo_signature_query)[0]
+        m = _duo_signature_pattern.search(element.text)
+        return m.group(1)
+    except:
+        duo_host_query = './/input[@name="duo_sig_request"]/@value'
+        return html_response.xpath(duo_host_query)[0]
 
 
 def _action_url_on_validation_success(html_response):


### PR DESCRIPTION
This fixes #42 - Parsing error when trying to login to Duo MFA to parse out the duo host and signature from the ADFS response page.

This was done in a backwards compatible fashion so it at first tries the existing parsing logic, and if that fails (try/catch) it falls back to trying the new way.  It could be better, but works great for us.  Improve if desired.

Thanks for this tool, works great (now)!