### PR TITLE
Fix Negotiate auth on non-domain-joined Windows hosts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requires = [
 ]
 
 if system() == 'Windows':
-    install_requires.append('requests-negotiate-sspi')
+    install_requires.append('requests-negotiate-sspi>=0.3.4')
 
 version = versioneer.get_version()
 


### PR DESCRIPTION
It recently came to my attention that the current use of requests-negotiate-sspi on Windows hosts was causing the module to fail if Negotiate authentication failed. This was due to our user-agent spoofing causing ADFS to continue redirecting us through the Integrated Windows Authentication (IWA) page's 401 response, since it only supports Negotiate auth - not form input.

This change passes the username and password through to the auth module, which lets Windows handle authentication properly in cases where Kerberos credentials are not available or are not accepted by the ADFS host.