### PR TITLE
Role arn as parameter

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -53,6 +53,10 @@ from . import role_chooser
     is_flag=True,
     help='Read username, password from standard input separated by a newline.',
 )
+@click.option(
+    '--role-arn',
+    help='Predefined role arn to select',
+)
 def login(
         profile,
         region,
@@ -62,6 +66,7 @@ def login(
         provider_id,
         s3_signature_version,
         stdin,
+        role_arn,
 ):
     """
     Authenticates an user with active directory credentials
@@ -94,7 +99,8 @@ def login(
         del username
         password = '########################################'
         del password
-
+    if(role_arn is not None):
+        config.role_arn=role_arn
     principal_arn, config.role_arn = role_chooser.choose_role_to_assume(config, principal_roles)
     if principal_arn is None or config.role_arn is None:
         click.echo('This account does not have access to any roles', err=True)


### PR DESCRIPTION
The enanchment #67 could be solved by this pull request.

The role_arn is already a configuration parameter. The parameter value is available in the configuration object so if the value is present as parameter just set it. The role_chooser works as aspected and the role_arn is selected.

Tested with an account with multiple roles. 

Hope this help.