### PR TITLE
Reformat role selection

### DIFF
--- a/aws_adfs/role_chooser.py
+++ b/aws_adfs/role_chooser.py
@@ -2,6 +2,17 @@ import collections
 import logging
 
 import click
+from future.utils import iteritems
+
+_ROLE_OPTION_FMT = '|{:<3}|{:<25}|{:<30}|{:<25}|'
+
+def _display_role_list(principal_roles):
+    click.echo(_ROLE_OPTION_FMT.format('#', 'Account', 'Role Name', 'Role ARN'))
+    idx = 0
+    for (account_name, account_roles) in iteritems(principal_roles):
+        for (arn, role_data) in iteritems(account_roles):
+            click.echo(_ROLE_OPTION_FMT.format(idx, account_name, role_data['name'], arn))
+            idx += 1
 
 
 def choose_role_to_assume(config, principal_roles):
@@ -38,14 +49,15 @@ def choose_role_to_assume(config, principal_roles):
     elif len(role_collection) > 1:
         logging.debug(u'Manual choice')
         click.echo(u'Please choose the role you would like to assume:')
-        i = 0
-        for account_name in principal_roles.keys():
-            roles = principal_roles[account_name]
-            click.echo('{}:'.format(account_name))
-            for role_arn in roles.keys():
-                role_entry = roles[role_arn]
-                click.echo('    [ {} -> {} ]: {}'.format(role_entry['name'].ljust(30, ' ' if i % 2 == 0 else '.'), i, role_arn))
-                i += 1
+        _display_role_list(principal_roles)
+        #i = 0
+        #for account_name in principal_roles.keys():
+        #    roles = principal_roles[account_name]
+        #    click.echo('{}:'.format(account_name))
+        #    for role_arn in roles.keys():
+        #        role_entry = roles[role_arn]
+        #        click.echo('    [ {} -> {} ]: {}'.format(role_entry['name'].ljust(30, ' ' if i % 2 == 0 else '.'), i, role_arn))
+        #        i += 1
 
         selected_index = click.prompt(text='Selection', type=click.IntRange(0, len(role_collection)))
 

--- a/aws_adfs/role_chooser.py
+++ b/aws_adfs/role_chooser.py
@@ -7,6 +7,7 @@ from future.utils import iteritems
 
 def _display_role_list(principal_roles):
     idx = 0
+    click.echo(u'Please choose the role you would like to assume:')
     for (account_name, account_roles) in iteritems(principal_roles):
         if account_name.startswith('Account:'):
             click.secho(account_name, fg='blue')
@@ -50,10 +51,10 @@ def choose_role_to_assume(config, principal_roles):
         chosen_role_arn = role_collection[0][1]
     elif len(role_collection) > 1:
         logging.debug(u'Manual choice')
-        click.echo(u'Please choose the role you would like to assume:')
         _display_role_list(principal_roles)
-
-        selected_index = click.prompt(text='Selection', type=click.IntRange(0, len(role_collection)))
+        prompt_text = 'Selection [{}-{}]'.format(0, len(role_collection) - 1)
+        selected_index = click.prompt(text=prompt_text,
+                                      type=click.IntRange(0, len(role_collection)))
 
         chosen_principal_arn = role_collection[selected_index][0]
         chosen_role_arn = role_collection[selected_index][1]

--- a/aws_adfs/role_chooser.py
+++ b/aws_adfs/role_chooser.py
@@ -4,14 +4,16 @@ import logging
 import click
 from future.utils import iteritems
 
-_ROLE_OPTION_FMT = '|{:<3}|{:<25}|{:<30}|{:<25}|'
 
 def _display_role_list(principal_roles):
-    click.echo(_ROLE_OPTION_FMT.format('#', 'Account', 'Role Name', 'Role ARN'))
     idx = 0
     for (account_name, account_roles) in iteritems(principal_roles):
+        if account_name.startswith('Account:'):
+            click.secho(account_name, fg='blue')
+        else:
+            click.secho('Account: {}'.format(account_name), fg='blue')
         for (arn, role_data) in iteritems(account_roles):
-            click.echo(_ROLE_OPTION_FMT.format(idx, account_name, role_data['name'], arn))
+            click.echo('[{:^3}] - {}'.format(idx, role_data['name']))
             idx += 1
 
 
@@ -50,14 +52,6 @@ def choose_role_to_assume(config, principal_roles):
         logging.debug(u'Manual choice')
         click.echo(u'Please choose the role you would like to assume:')
         _display_role_list(principal_roles)
-        #i = 0
-        #for account_name in principal_roles.keys():
-        #    roles = principal_roles[account_name]
-        #    click.echo('{}:'.format(account_name))
-        #    for role_arn in roles.keys():
-        #        role_entry = roles[role_arn]
-        #        click.echo('    [ {} -> {} ]: {}'.format(role_entry['name'].ljust(30, ' ' if i % 2 == 0 else '.'), i, role_arn))
-        #        i += 1
 
         selected_index = click.prompt(text='Selection', type=click.IntRange(0, len(role_collection)))
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = [
     'boto3>=1.6.2',
     'requests[security]',
     'configparser',
+    'future'
 ]
 
 if system() == 'Windows':


### PR DESCRIPTION
This program has been a big time-saver for me at work, so thank you for writing it. My co-workers and I were having trouble easily finding the right role in the list that appears during `aws-adfs login`. I've modified the formatting of the list of roles in a way that I hope is easier to read quickly.

The original list looked like:
```
Please choose the role you would like to assume:
Account: 123456789012: 
[ YO_AWS_PRO-Bamboozler_Really_Cool_Admins -> 0 ]: arn:aws:iam::123456789012:role/YO_AWS_PRO-Bamboozler_Really_Cool_Admins
Account: 345678901234: 
[ YO_AWS_PRO-CICD_Read_Only -> 1 ]: arn:aws:iam::345678901234:role/YO_AWS_PRO-CICD_Read_Only
```
In the original output format, the selection number is always in a different place based on the length of the role name. In addition, the ARN for each role is printed out in full, which makes my terminal seem a bit cluttered.

My updated formatting shows as:
```
Please choose the role you would like to assume:
Account: 123456789012 
[ 0 ] - YO_AWS_PRO-Bamboozler_Really_Cool_Admins
Account: 345678901234
[ 1 ] - YO_AWS_PRO-CICD_Read_Only
Account: 567890123456
[ 2 ] - YO_AWS_Important-Project-NonProd_Really_Cool_Admins
[ 3 ] - YO_AWS_Important-Project_Really_Cool_Admins
Account: 789012345678
[ 4 ] - YO_AWS_PRO-HyperProject_Really_Cool_Admins
Selection [0-4]: 2
```
I've made it so the selection number is always in the same place for each role for faster selection. Also, I've omitted the ARN since it does not actually include any additional information; the ARN for a role has the format `arn:aws:iam::<account number>:role/<role name>`, so there's less of a reason to print out ARNs alongside the account numbers and the role names themselves.

If you don't like these changes or if this code does not meet your standards, no worries! Thanks again for writing this utility.