### PR TITLE
Added flag for disabling Kerberos SSO authentication via SSPI

### DIFF
--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -8,7 +8,7 @@ from . import html_roles_fetcher
 from . import roles_assertion_extractor
 
 
-def authenticate(config, username=None, password=None, assertfile=None):
+def authenticate(config, username=None, password=None, assertfile=None, sspi=True):
 
     response, session = html_roles_fetcher.fetch_html_encoded_roles(
         adfs_host=config.adfs_host,
@@ -17,6 +17,7 @@ def authenticate(config, username=None, password=None, assertfile=None):
         provider_id=config.provider_id,
         username=username,
         password=password,
+        sspi=sspi
     )
 
     assertion = None
@@ -88,7 +89,7 @@ def _aggregate_roles_by_account_alias(session,
 
         if account_no not in account_aliases:
             account_aliases[account_no] = account_no
-        
+
         if account_aliases[account_no] not in aggregated_accounts:
             aggregated_accounts[account_aliases[account_no]] = {}
         aggregated_accounts[account_aliases[account_no]][role_arn] = {'name': role_name, 'principal_arn': principal_arn}
@@ -113,7 +114,7 @@ def _strategy(response, config, session, assertfile=None):
         def extract():
             return symantec_vip_access.extract(html_response, config.ssl_verification, session)
         return extract
-    
+
     def _file_extractor():
         def extract():
             return roles_assertion_extractor.extract_file(assertfile)

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -31,7 +31,8 @@ def fetch_html_encoded_roles(
         ssl_verification_enabled,
         provider_id,
         username=None,
-        password=None
+        password=None,
+        sspi=True
 ):
     # Initiate session handler
     session = requests.Session()
@@ -48,7 +49,7 @@ def fetch_html_encoded_roles(
             u'The error: {}'.format(error_message)
         )
 
-    if _auth_provider:
+    if _auth_provider and sspi:
         domain = None
         if username:
             if '@' in username: # User principal name (UPN) format

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -88,6 +88,11 @@ from . import role_chooser
     '--assertfile',
     help='Use SAML assertion response from a local file'
 )
+@click.option(
+    '--sspi/--no-sspi',
+    default=True,
+    help='Whether or not to use Kerberos SSO authentication via SSPI, which may not work in some environments.',
+)
 def login(
         profile,
         region,
@@ -103,7 +108,8 @@ def login(
         printenv,
         role_arn,
         session_duration,
-        assertfile
+        assertfile,
+        sspi
 ):
     """
     Authenticates an user with active directory credentials
@@ -135,7 +141,7 @@ def login(
         else:
             username, password = _get_user_credentials(config)
 
-        principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, username, password)
+        principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, username, password, sspi=sspi)
 
         username = '########################################'
         del username


### PR DESCRIPTION
Added option to disable SSPI authentication, which may not work in some environments.

This is similar to avoidik's pull request, but without the double negation. Mimics how ssl-verification is flagged.