### PR TITLE
login.py

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -128,9 +128,9 @@ def login(
     if assertion is None:
         if stdin:
             username, password = _stdin_user_credentials()
-        if env:
+        elif env:
             username, password = _env_user_credentials()
-        if authfile:
+        elif authfile:
             username, password = _file_user_credentials(config.profile, authfile)
         else:
             username, password = _get_user_credentials(config)


### PR DESCRIPTION
The --env flag is not being called and therefore using the env parameter will not work.