### PR TITLE
Save DUO session cookies

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -118,6 +118,9 @@ def _retrieve_roles_page(roles_page_url, context, session, ssl_verification_enab
             )
         )
 
+    # Save session cookies to avoid having to repeat MFA on each login
+    session.cookies.save(ignore_discard=True)
+
     html_response = ET.fromstring(response.text, ET.HTMLParser())
     return roles_assertion_extractor.extract(html_response)
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -85,6 +85,10 @@ from . import role_chooser
     type=int,
 )
 @click.option(
+    '--mfa-auth-method',
+    help='The multifactor authentication method to use when more than one is available'
+)
+@click.option(
     '--assertfile',
     help='Use SAML assertion response from a local file'
 )
@@ -108,6 +112,7 @@ def login(
         printenv,
         role_arn,
         session_duration,
+        mfa_auth_method,
         assertfile,
         sspi
 ):
@@ -123,6 +128,7 @@ def login(
         provider_id,
         s3_signature_version,
         session_duration,
+        mfa_auth_method,
     )
 
     _verification_checks(config)
@@ -332,6 +338,7 @@ def _store(config, aws_session_token):
         config_file.set(profile, 'adfs_config.role_arn', config.role_arn)
         config_file.set(profile, 'adfs_config.adfs_host', config.adfs_host)
         config_file.set(profile, 'adfs_config.adfs_user', config.adfs_user)
+        config_file.set(profile, 'adfs_config.mfa_auth_method', config.mfa_auth_method)
         if config.s3_signature_version:
             config_file.set(profile, 's3', '\nsignature_version = {}'.format(config.s3_signature_version))
         config_file.set(profile, 'adfs_config.session_duration', config.session_duration)

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -15,6 +15,7 @@ def get_prepared_config(
         provider_id,
         s3_signature_version,
         session_duration,
+        mfa_auth_method,
 ):
     """
     Prepares ADF configuration for login task.
@@ -54,6 +55,7 @@ def get_prepared_config(
         adfs_config.s3_signature_version
     )
     adfs_config.session_duration = default_if_none(session_duration, adfs_config.session_duration)
+    adfs_config.mfa_auth_method = default_if_none(mfa_auth_method, adfs_config.mfa_auth_method)
 
     return adfs_config
 
@@ -104,6 +106,8 @@ def create_adfs_default_config(profile):
     # AWS STS session duration, default is 3600 seconds
     config.session_duration = int(3600)
 
+    config.mfa_auth_method = ''
+
     return config
 
 
@@ -151,6 +155,7 @@ def _load_adfs_config_from_stored_profile(adfs_config, profile):
         adfs_config.adfs_host = config.get_or(profile, 'adfs_config.adfs_host', adfs_config.adfs_host)
         adfs_config.adfs_user = config.get_or(profile, 'adfs_config.adfs_user', adfs_config.adfs_user)
         adfs_config.provider_id = config.get_or(profile, 'adfs_config.provider_id', adfs_config.provider_id)
+        adfs_config.mfa_auth_method = config.get_or(profile, 'adfs_config.mfa_auth_method', adfs_config.mfa_auth_method)
 
         adfs_config.s3_signature_version = None
         rawS3SubSection = config.get_or(profile, 's3', None)


### PR DESCRIPTION
Prevent having to repeat MFA when original login is still valid.

As the cookies weren't saved, the DUO authentication was having to be repeated unnecessarily on each run of the command. Saving the cookies means the MFA with DUO is only repeated once the session has expired.