### PR TITLE
Save duo session cookies

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -118,6 +118,9 @@ def _retrieve_roles_page(roles_page_url, context, session, ssl_verification_enab
             )
         )
 
+    # Save session cookies to avoid having to repeat MFA on each login
+    session.cookies.save(ignore_discard=True)
+
     html_response = ET.fromstring(response.text, ET.HTMLParser())
     return roles_assertion_extractor.extract(html_response)
 


### PR DESCRIPTION
Save the session cookies after a DUO authentication request. Prevents having to repeat the MFA login process when not required.