### PR TITLE
Add support for Azure MFA Server

### DIFF
--- a/aws_adfs/_azure_mfa_authenticator.py
+++ b/aws_adfs/_azure_mfa_authenticator.py
@@ -1,0 +1,68 @@
+import click
+import lxml.etree as ET
+
+import logging
+
+from . import roles_assertion_extractor
+
+def extract(html_response, ssl_verification_enabled, session):
+    """
+    :param html_response: html result of parsing http response
+    :param ssl_verification_enabled: bool to enable SSL verification
+    :param session: current requests Session object
+    :return:
+    """
+
+    roles_page_url = _action_url_on_validation_success(html_response)
+
+    click.echo('Additional verification is required. Please check your mobile device', err=True)
+
+    # The POST call in this function hangs until verification is completed
+    return _retrieve_roles_page(
+        roles_page_url,
+        _context(html_response),
+        session,
+        ssl_verification_enabled
+    )
+
+    
+def _retrieve_roles_page(roles_page_url, context, session, ssl_verification_enabled):
+    response = session.post(
+        roles_page_url,
+        verify=ssl_verification_enabled,
+        allow_redirects=True,
+        data={
+            'AuthMethod': 'AzureMfaServerAuthentication',
+            'Context': context,
+        }
+    )
+    logging.debug(u'''Request:
+            * url: {}
+            * headers: {}
+        Response:
+            * status: {}
+            * headers: {}
+            * body: {}
+        '''.format(roles_page_url, response.request.headers, response.status_code, response.headers,
+                   response.text))
+
+    if response.status_code != 200:
+        raise click.ClickException(
+            u'Issues during redirection to aws roles page. The error response {}'.format(
+                response
+            )
+        )
+
+    html_response = ET.fromstring(response.text, ET.HTMLParser())
+    return roles_assertion_extractor.extract(html_response)
+
+
+def _context(html_response):
+    context_query = './/input[@id="context"]'
+    element = html_response.find(context_query)
+    return element.get('value')
+
+def _action_url_on_validation_success(html_response):
+    post_url_query = './/form[@id="options"]'
+    element = html_response.find(post_url_query)
+    return element.get('action')

--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -5,6 +5,7 @@ from . import account_aliases_fetcher
 from . import _duo_authenticator as duo_auth
 from . import _rsa_authenticator as rsa_auth
 from . import _symantec_vip_access as symantec_vip_access
+from . import _azure_mfa_authenticator as azure_mfa_auth
 from . import html_roles_fetcher
 from . import roles_assertion_extractor
 
@@ -126,6 +127,11 @@ def _strategy(response, config, session, assertfile=None):
             return rsa_auth.extract(html_response, config.ssl_verification, session)
         return extract
 
+    def _azure_mfa_extractor():
+        def extract():
+            return azure_mfa_auth.extract(html_response, config.ssl_verification, session)
+        return extract
+
     if assertfile is None:
         chosen_strategy = _plain_extractor
     else:
@@ -137,6 +143,8 @@ def _strategy(response, config, session, assertfile=None):
         chosen_strategy = _symantec_vip_extractor
     elif _is_rsa_authentication(html_response):
         chosen_strategy = _rsa_auth_extractor
+    elif _is_azure_mfa_authentication(html_response):
+        chosen_strategy = _azure_mfa_extractor
 
     return chosen_strategy()
 
@@ -162,4 +170,12 @@ def _is_rsa_authentication(html_response):
     return (
         element is not None
         and element.get('value') == 'SecurIDAuthentication'
+    )
+
+def _is_azure_mfa_authentication(html_response):
+    auth_method = './/input[@id="authMethod"]'
+    element = html_response.find(auth_method)
+    return (
+        element is not None
+        and element.get('value') == 'AzureMfaServerAuthentication'
     )


### PR DESCRIPTION
This commit adds support for Azure MFA authentication. The way this auth method works is an out-of-band message or phone call is sent to a user's configured mobile device. The user then authorizes the login attempt and the request proceeds.

This is very similar to the existing Symantec VIP authenticator, except no extra information is forwarded to the server.

As the process is very similar to the Symantec method I have reused a lot of the code from that module.

I have tested this method and did not encounter any issues. In the event of a timeout (or any other failure). The roles_assertion_extractor will find and print the error.