### PR TITLE
Fix Duo authentication initiation failure messages

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -349,13 +349,13 @@ def _initiate_authentication(duo_host, duo_request_signature, roles_page_url, se
                response.text))
 
     if response.status_code != 200 or response.url is None:
-        return None, False
+        return (None, None, None), False
 
     o = urlparse(response.url)
     query = parse_qs(o.query)
 
     if 'sid' not in query:
-        return None, False
+        return (None, None, None), False
 
     sid = query['sid']
     html_response = ET.fromstring(response.text, ET.HTMLParser())


### PR DESCRIPTION
Without this change, authentication initiation failures results in the following obscure message:

```
```Traceback (most recent call last):
  File "/home/nsd/.pyenv/versions/aws-adfs/bin/aws-adfs", line 10, in <module>
    sys.exit(cli())
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/aws_adfs/login.py", line 131, in login
    principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, assertfile=assertfile)
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/aws_adfs/authenticator.py", line 32, in authenticate
    principal_roles, assertion, aws_session_duration = extract_strategy()
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/aws_adfs/authenticator.py", line 112, in extract
    return duo_auth.extract(html_response, config.ssl_verification, session)
  File "/home/nsd/.pyenv/versions/2.7.16/envs/aws-adfs/lib/python2.7/site-packages/aws_adfs/_duo_authenticator.py", line 42, in extract
    ssl_verification_enabled
TypeError: 'NoneType' object is not iterable```
```

The issue is that the result of `_initiate_authentication()` is unpacked as `(sid, preferred_factor, preferred_device), initiated` at https://github.com/venth/aws-adfs/compare/master...pdecat:fix-duo-failure-messages?expand=1#diff-0584fbc181c07f609204d3aa5779348fL37

```
# python2
Python 2.7.16 (default, Apr  6 2019, 01:42:57) 
[GCC 8.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> (a, b, c), d = None, True
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'NoneType' object is not iterable
>>> (a, b, c), d = (None, None, None), True
>>> 
```

With python3, the error message is a bit different but the resolution is the same:

```
# python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> (a, b, c), d = None, True
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: cannot unpack non-iterable NoneType object
>>> (a, b, c), d = (None, None, None), True
>>>
```

Note: I've tried to implement a unit test case for this but the mocking necessary to exercize `aws_adfs/_duo_authenticator.py` during unit tests is not trivial.