### PR TITLE
Respect AWS_DEFAULT_PROFILE if defined

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -16,6 +16,7 @@ from . import role_chooser
 @click.command()
 @click.option(
     '--profile',
+    default=lambda: environ.get('AWS_DEFAULT_PROFILE', 'default'),
     help='AWS cli profile that will be authenticated.\n'
          'After successful authentication just use:\n'
          'aws --profile <authenticated profile> <service> ...',

--- a/aws_adfs/reset.py
+++ b/aws_adfs/reset.py
@@ -2,12 +2,14 @@ import configparser
 
 import click
 
+from os import environ
 from .prepare import create_adfs_default_config
 
 
 @click.command()
 @click.option(
     '--profile',
+    default=lambda: environ.get('AWS_DEFAULT_PROFILE', 'default'),
     help='AWS cli profile that will be removed'
 )
 def reset(profile):


### PR DESCRIPTION
AWS CLI gets predefined profile from AWS_DEFAULT_PROFILE if defined.
Otherwise profile "default" is used.

https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html#using-profiles

This patch adds the same behavior as AWS CLI.