### PR TITLE
Handle sspi like other config options

### DIFF
--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -10,8 +10,7 @@ from . import html_roles_fetcher
 from . import roles_assertion_extractor
 
 
-def authenticate(config, username=None, password=None, assertfile=None, sspi=True):
-
+def authenticate(config, username=None, password=None, assertfile=None):
     response, session = html_roles_fetcher.fetch_html_encoded_roles(
         adfs_host=config.adfs_host,
         adfs_cookie_location=config.adfs_cookie_location,
@@ -20,7 +19,7 @@ def authenticate(config, username=None, password=None, assertfile=None, sspi=Tru
         provider_id=config.provider_id,
         username=username,
         password=password,
-        sspi=sspi
+        sspi=config.sspi
     )
 
     assertion = None
@@ -160,10 +159,14 @@ def _is_duo_authentication(html_response):
 def _is_symantec_vip_authentication(html_response):
     auth_method = './/input[@id="authMethod"]'
     element = html_response.find(auth_method)
-    return (
+    if (
         element is not None
         and element.get('value') == 'SymantecVipAdapter'
-    )
+    ) or (
+        element is not None
+        and element.get('value') == 'VIPAuthenticationProviderWindowsAccountName'
+    ):
+        return True
 
 def _is_rsa_authentication(html_response):
     auth_method = './/input[@id="authMethod"]'

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -11,13 +11,9 @@ except ImportError:
 _auth_provider = None
 _headers = {'Accept-Language': 'en'}
 
-# Support for Kerberos SSO on Windows via requests_negotiate_sspi
-# also requires tricking the server into thinking we're using IE
-# so that it servers up a redirect to the IWA page.
 try:
     from requests_negotiate_sspi import HttpNegotiateAuth
     _auth_provider = HttpNegotiateAuth
-    _headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko'
 except ImportError:
     pass
 
@@ -35,6 +31,13 @@ def fetch_html_encoded_roles(
         password=None,
         sspi=True
 ):
+
+    # Support for Kerberos SSO on Windows via requests_negotiate_sspi
+    # also requires tricking the server into thinking we're using IEq
+    # so that it servers up a redirect to the IWA page.
+    if sspi:
+        _headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko'
+
     # Initiate session handler
     session = requests.Session()
     session.cookies = cookielib.LWPCookieJar(filename=adfs_cookie_location)

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -96,7 +96,7 @@ from . import role_chooser
 )
 @click.option(
     '--sspi/--no-sspi',
-    default=True,
+    default=None,
     help='Whether or not to use Kerberos SSO authentication via SSPI, which may not work in some environments.',
 )
 def login(
@@ -131,6 +131,7 @@ def login(
         provider_id,
         s3_signature_version,
         session_duration,
+        sspi
     )
 
     _verification_checks(config)
@@ -155,7 +156,7 @@ def login(
         if not password:
             password = click.prompt('Password', type=str, hide_input=True)
 
-        principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, config.adfs_user, password, sspi=sspi)
+        principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, config.adfs_user, password)
 
         password = '########################################'
         del password
@@ -263,6 +264,7 @@ def _emit_summary(config, session_duration):
             config.provider_id,
             config.s3_signature_version,
             config.session_duration,
+            config.sspi,
         )
     )
 
@@ -355,6 +357,7 @@ def _store(config, aws_session_token):
             config_file.set(profile, 's3', '\nsignature_version = {}'.format(config.s3_signature_version))
         config_file.set(profile, 'adfs_config.session_duration', config.session_duration)
         config_file.set(profile, 'adfs_config.provider_id', config.provider_id)
+        config_file.set(profile, 'adfs_config.sspi', config.sspi)
 
     store_config(config.profile, config.aws_credentials_location, credentials_storer)
     if config.profile == 'default':

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -16,6 +16,7 @@ def get_prepared_config(
         provider_id,
         s3_signature_version,
         session_duration,
+        sspi,
 ):
     """
     Prepares ADF configuration for login task.
@@ -36,6 +37,7 @@ def get_prepared_config(
     :param provider_id: Provider ID, e.g urn:amazon:webservices (optional)
     :param s3_signature_version: s3 signature version
     :param session_duration: AWS STS session duration (default 1 hour)
+    :param sspi: Whether SSPI is enabled
     """
     def default_if_none(value, default):
         return value if value is not None else default
@@ -46,7 +48,6 @@ def get_prepared_config(
 
     _create_base_aws_cli_config_files_if_needed(adfs_config)
     _load_adfs_config_from_stored_profile(adfs_config, adfs_config.profile)
-
     adfs_config.ssl_verification = default_if_none(ssl_verification, adfs_config.ssl_verification)
     adfs_config.adfs_ca_bundle = default_if_none(adfs_ca_bundle, adfs_config.adfs_ca_bundle)
     adfs_config.region = default_if_none(region, adfs_config.region)
@@ -58,6 +59,7 @@ def get_prepared_config(
         adfs_config.s3_signature_version
     )
     adfs_config.session_duration = default_if_none(session_duration, adfs_config.session_duration)
+    adfs_config.sspi = default_if_none(sspi, adfs_config.sspi)
 
     return adfs_config
 
@@ -110,6 +112,9 @@ def create_adfs_default_config(profile):
 
     # AWS STS session duration, default is 3600 seconds
     config.session_duration = int(3600)
+
+    # Whether SSPI is enabled
+    config.sspi = True
 
     return config
 
@@ -173,6 +178,9 @@ def _load_adfs_config_from_stored_profile(adfs_config, profile):
         adfs_config.session_duration = config.get_or(
             profile, 'adfs_config.session_duration',
             adfs_config.session_duration)
+        adfs_config.sspi = ast.literal_eval(config.get_or(
+            profile, 'adfs_config.sspi',
+            str(adfs_config.sspi)))
 
     if profile == 'default':
         load_from_config(adfs_config.aws_config_location, profile, load_config)

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -297,6 +297,7 @@ class TestAuthenticator:
         self.irrelevant_config.ssl_verification = True
         self.irrelevant_config.adfs_ca_bundle = None
         self.irrelevant_config.provider_id = 'irrelevant provider identifier'
+        self.irrelevant_config.sspi = True
 
         self.http_session = type('', (), {})()
         self.http_session.post = lambda *args, **kwargs: None

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -22,6 +22,7 @@ class TestConfigPreparation:
         default_provider_id = 'default_provider_id'
         default_s3_signature_version = None
         default_session_duration = 3600
+        default_sspi = False
 
         # when configuration is prepared for not existing profile
         adfs_config = prepare.get_prepared_config(
@@ -34,6 +35,7 @@ class TestConfigPreparation:
             default_provider_id,
             default_s3_signature_version,
             default_session_duration,
+            default_sspi,
         )
 
         # then resolved config contains defaults values
@@ -58,13 +60,14 @@ class TestConfigPreparation:
         # and defaults are setup as follows
         default_ssl_config = True
         default_adfs_ca_bundle = None
+        default_sspi = True
         irrelevant_region = 'irrelevant_region'
         irrelevant_adfs_host = 'irrelevant_adfs_host'
         irrelevant_output_format = 'irrelevant_output_format'
         irrelevant_provider_id = 'irrelevant_provider_id'
         irrelevant_s3_signature_version = 'irrelevant_s3_signature_version'
         irrelevant_session_duration = 'irrelevant_session_duration'
-
+        
         # when configuration is prepared for existing profile
         adfs_config = prepare.get_prepared_config(
             empty_profile,
@@ -76,8 +79,10 @@ class TestConfigPreparation:
             irrelevant_provider_id,
             irrelevant_s3_signature_version,
             irrelevant_session_duration,
+            default_sspi,            
         )
 
         # then resolved ssl verification holds the default value
         assert default_ssl_config == adfs_config.ssl_verification
         assert default_adfs_ca_bundle == adfs_config.adfs_ca_bundle
+        assert default_sspi == adfs_config.sspi

--- a/test/test_fetch_html_encoded_roles.py
+++ b/test/test_fetch_html_encoded_roles.py
@@ -9,6 +9,7 @@ class TestFetchHtmlEncodedRoles:
         # given adfs host which doesn't care that ssl is enabled or not
         adfs_host = 'adfs.awsome.com'
         ssl_verification_is_irrelevant = False
+        sspi_is_irrelevant=False
 
         requests = html_roles_fetcher.requests = mock.Mock()
 
@@ -42,6 +43,7 @@ class TestFetchHtmlEncodedRoles:
             provider_id=no_provider_id_provided,
             username=no_credentials_provided,
             password=no_credentials_provided,
+            sspi=sspi_is_irrelevant
         )
 
         # then returned html is empty
@@ -53,6 +55,7 @@ class TestFetchHtmlEncodedRoles:
         adfs_host = 'adfs.awsome.com'
         provider_id = None
         ssl_verification_is_irrelevant = False
+        sspi_is_irrelevant = False
 
         requests = html_roles_fetcher.requests = mock.Mock()
 
@@ -89,6 +92,7 @@ class TestFetchHtmlEncodedRoles:
             provider_id=no_provider_id_provided,
             username=no_credentials_provided,
             password=no_credentials_provided,
+            sspi=sspi_is_irrelevant
         )
 
         # then en was requested as preferred language


### PR DESCRIPTION
Changes covered:

- Enhanced Symantec Code to handle both the 'old' and 'new' Auth Methods.  I am unable to find any documentation on why or when these values changed, but our system still uses the 'old' ones. See [here](https://github.com/venth/aws-adfs/pull/96) for background.  This should handle both, but has **only been tested against the old**
- SSPI Fixes:
  - Handle SSPI like other config options (store in profile, etc)
  - Only set user-agent header when SSPI is enabled.  In our environment (No SSPI), this causes a 401.
  - As a side-effect of the config change, this [call](https://github.com/venth/aws-adfs/blob/5c9852ebb693e9f0fe90338829aff207aa456a84/aws_adfs/login.py#L139) correctly uses sspi.  Without this change, the call is always made with sspi enabled, which causes an exception.  If you need reproduction of this let me know.
- Updated test cases to cover changes