### PR TITLE
Add FIDO/U2F support to Duo authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,32 @@ aws-adfs integrates with:
     deactivate
     ```
 
+* Windows 10
+
+   - Install latest supported Visual C++ downloads from Microsoft for Visual Studio 2015, 2017 and 2019:
+      - https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads
+      - https://aka.ms/vs/16/release/vc_redist.x64.exe
+    - Install Python 3.7 from Microsoft Store:
+      - https://www.microsoft.com/en-us/p/python-37/9nj46sx7x90p
+    - Start PowerShell as Administrator
+    - Go to `C:\Program Files`:
+        ```
+        C:
+        cd 'C:\Program Files\'
+        ```
+    - Create virtual env:
+      ```
+      python3 -m venv aws-adfs
+      ```
+    - Install `aws-adfs`:
+      ```
+      & 'C:\Program Files\aws-adfs\Scripts\pip' install aws-adfs
+      ```
+    - Run it:
+      ```
+      & 'C:\Program Files\aws-adfs\Scripts\aws-adfs' login --adfs-host=your-adfs-hostname
+      ```
+
 # Examples of usage
 
 ## `aws-adfs`
@@ -224,9 +250,26 @@ aws-adfs integrates with:
 
 # Known issues
 * duo-security
-    * Error: Cannot begin authentication process. The error response: {"message": "Unknown authentication method.", "stat": "FAIL"}
-    
-        Please setup preferred auth method in duo-sercurity settings (settings' -> 'My Settings & Devices').
+
+    `Error: Cannot begin authentication process. The error response: {"message": "Unknown authentication method.", "stat": "FAIL"}`
+
+    Please setup preferred auth method in duo-security settings (settings' -> 'My Settings & Devices').
+
+* USB FIDO U2F does not work in Windows Subsystem for Linux (WSL)
+
+    `OSError: [Errno 2] No such file or directory: '/sys/class/hidraw'`
+
+    USB devices are not accessible in WSL, please install and run `aws-adfs` on the Windows 10 host and then access the credentials in WSL from the filesystem. Example:
+
+    ```
+    export AWS_CONFIG_FILE=/mnt/c/Users/username/.aws/config
+    export AWS_SHARED_CREDENTIALS_FILE=/mnt/c/Users/username/.aws/credentials
+    ```
+
+*  FIDO U2F devices are not detected on Windows 10 build 1903 or newer
+
+    Running `aws-adfs` as Administrator is required since Windows 10 build 1903 to access FIDO U2F devices, cf. https://github.com/Yubico/python-fido2/issues/55)
+
 * in cases of trouble with lxml please install
 
   ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ As of version 0.2.0, this tool acts on the 'default' profile unless an alternate
 ### MFA integration
 
 aws-adfs integrates with:
-* [duo security](https://duo.com) MFA provider
+* [duo security](https://duo.com) MFA provider with support for FIDO U2F hardware authenticator
 * [Symantec VIP](https://vip.symantec.com/) MFA provider
 * [RSA SecurID](https://www.rsa.com/) MFA provider
 

--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -282,7 +282,7 @@ def _verify_authentication_status(duo_host, sid, duo_transaction_id, session,
             )
 
         if json_response['response']['status_code'] in ['pushed', 'answered', 'allow']:
-            return
+            return duo_transaction_id
 
         if json_response['response']['status_code'] == 'u2f_sent' and len(json_response['response']['u2f_sign_request']) > 0:
             u2f_sign_requests = json_response['response']['u2f_sign_request']

--- a/aws_adfs/commands.py
+++ b/aws_adfs/commands.py
@@ -42,7 +42,13 @@ def cli(verbose):
         stream=sys.stderr,
         level=logging.DEBUG if verbose else logging.ERROR,
     )
-
+    if verbose:
+        try:
+            import http.client as http_client
+        except ImportError:
+            # Python 2
+            import httplib as http_client
+        http_client.HTTPConnection.debuglevel = 1
 
 cli.add_command(list_profiles.list_profiles)
 cli.add_command(login.login)

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -40,7 +40,12 @@ def fetch_html_encoded_roles(
 
     # Initiate session handler
     session = requests.Session()
-    session.cookies = cookielib.LWPCookieJar(filename=adfs_cookie_location)
+
+    # LWPCookieJar has an issue on Windows when cookies have an 'expires' date too far in the future and they are converted from timestamp to datetime.
+    # MozillaCookieJar works because it does not convert the timestamps.
+    # Duo uses 253402300799 for its cookies which translates into 9999-12-31T23:59:59Z.
+    # Windows 64bit maximum date is 3000-12-31T23:59:59Z, and 32bit is 2038-01-18T23:59:59Z.
+    session.cookies = cookielib.MozillaCookieJar(filename=adfs_cookie_location)
 
     try:
         have_creds = (username and password) or _auth_provider

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ tests_require = [
 ]
 
 install_requires = [
-    'lxml',
+    'lxml<4.4.0;python_version<"3.5"',
+    'lxml;python_version>="3.5"',
     'click',
     'botocore>=1.12.6',
     'boto3>=1.9.6',

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ install_requires = [
     'boto3>=1.9.6',
     'requests[security]',
     'configparser',
+    'fido2',
 ]
 
 if system() == 'Windows':

--- a/test/test_fetch_html_encoded_roles.py
+++ b/test/test_fetch_html_encoded_roles.py
@@ -27,7 +27,7 @@ class TestFetchHtmlEncodedRoles:
         cookie_jar.load = mock.Mock(side_effect=IOError('No cookie. Still hungry'))
         cookie_jar.clear = mock.Mock()
         html_roles_fetcher.cookielib = mock.Mock()
-        html_roles_fetcher.cookielib.LWPCookieJar = mock.Mock(return_value=cookie_jar)
+        html_roles_fetcher.cookielib.MozillaCookieJar = mock.Mock(return_value=cookie_jar)
 
         # and credentials are not provided
         no_credentials_provided = None


### PR DESCRIPTION
This PR adds support for FIDO/U2F to Duo authentication.

If Duo reports U2F is supported for the user, it is used concurrently to the default authentication method.

~It's a rough draft that works but needs cleanup, hence the _WIP_.
I opened the PR now to get early feedback if possible.~

~Right now, if Duo reports U2F is supported for the user, only that authentication method is used.~

Example usage shown here: https://github.com/venth/aws-adfs/pull/127#issuecomment-534110072

Tested in USB mode with:
 - Yubikey Neo
 - Yubikey 5 NFC
 - Yubikey 5 Nano

It should support NFC mode too but that is not tested yet.

TODO:
 - [x] manage default authentication (call or push) concurrently to U2F
 - [x] manage multiple U2F better (right now, each device is tried sequentially)
 - [x] cleanup code
 - [ ] add tests
 - [x] add documentation



