### PR TITLE
Use MozillaCookieJar to support cookies with "expires" far in the future on Windows

### DIFF
--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -40,7 +40,12 @@ def fetch_html_encoded_roles(
 
     # Initiate session handler
     session = requests.Session()
-    session.cookies = cookielib.LWPCookieJar(filename=adfs_cookie_location)
+
+    # LWPCookieJar has an issue on Windows when cookies have an 'expires' date too far in the future and they are converted from timestamp to datetime.
+    # MozillaCookieJar works because it does not convert the timestamps.
+    # Duo uses 253402300799 for its cookies which translates into 9999-12-31T23:59:59Z.
+    # Windows 64bit maximum date is 3000-12-31T23:59:59Z, and 32bit is 2038-01-18T23:59:59Z.
+    session.cookies = cookielib.MozillaCookieJar(filename=adfs_cookie_location)
 
     try:
         have_creds = (username and password) or _auth_provider

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ tests_require = [
 ]
 
 install_requires = [
-    'lxml',
+    'lxml<4.4.0;python_version<"3.5"',
+    'lxml;python_version>="3.5"',
     'click',
     'botocore>=1.12.6',
     'boto3>=1.9.6',

--- a/test/test_fetch_html_encoded_roles.py
+++ b/test/test_fetch_html_encoded_roles.py
@@ -27,7 +27,7 @@ class TestFetchHtmlEncodedRoles:
         cookie_jar.load = mock.Mock(side_effect=IOError('No cookie. Still hungry'))
         cookie_jar.clear = mock.Mock()
         html_roles_fetcher.cookielib = mock.Mock()
-        html_roles_fetcher.cookielib.LWPCookieJar = mock.Mock(return_value=cookie_jar)
+        html_roles_fetcher.cookielib.MozillaCookieJar = mock.Mock(return_value=cookie_jar)
 
         # and credentials are not provided
         no_credentials_provided = None


### PR DESCRIPTION
`LWPCookieJar` has an issue on Windows when cookies have `expires` dates too far in the future and they are converted from timestamp to datetime.

With aws-adfs 1.17.0:

```
PS C:\> & C:\aws-adfs\Scripts\pip install aws-adfs==1.17.0

PS C:\> & C:\aws-adfs\Scripts\aws-adfs login --region=eu-west-1 --adfs-host=sso.mydomain.net --ssl-verification --session-duration=3600 --no-sspi                                       2019-08-23 11:05:06,588 [authenticator authenticator.py:authenticate] [3220-MainProcess] [7008-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
Password:
Sending request for authentication
Waiting for additional authentication
Going for aws roles
Traceback (most recent call last):
  File "C:\aws-adfs\Scripts\aws-adfs-script.py", line 11, in <module>
    load_entry_point('aws-adfs==1.17.0', 'console_scripts', 'aws-adfs')()
  File "c:\aws-adfs\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "c:\aws-adfs\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "c:\aws-adfs\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\aws-adfs\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\aws-adfs\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "c:\aws-adfs\lib\site-packages\aws_adfs\login.py", line 159, in login
    principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, config.adfs_user, password)
  File "c:\aws-adfs\lib\site-packages\aws_adfs\authenticator.py", line 33, in authenticate
    principal_roles, assertion, aws_session_duration = extract_strategy()
  File "c:\aws-adfs\lib\site-packages\aws_adfs\authenticator.py", line 113, in extract
    return duo_auth.extract(html_response, config.ssl_verification, session)
  File "c:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py", line 76, in extract
    '{}:{}'.format(auth_signature, _app(duo_request_signature)),
  File "c:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py", line 122, in _retrieve_roles_page
    session.cookies.save(ignore_discard=True)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 1890, in save
    f.write(self.as_lwp_str(ignore_discard, ignore_expires))
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 1877, in as_lwp_str
    r.append("Set-Cookie3: %s" % lwp_cookie_str(cookie))
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 1838, in lwp_cookie_str
    time2isoz(float(cookie.expires))))
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 101, in time2isoz
    dt = datetime.datetime.utcfromtimestamp(t)
OSError: [Errno 22] Invalid argument
```

Using pdb, we can see the following cookies are set (sensitive values redacted):

```
PS C:\> & C:\aws-adfs\Scripts\python -m pdb C:\aws-adfs\Scripts\aws-adfs-script.py login --profile=claranet --region=eu-west-1 --adfs-host=sso.mydomain.net --ssl-verification --session-duration=3600 --no-sspi
> c:\aws-adfs\scripts\aws-adfs-script.py(3)<module>()
-> __requires__ = 'aws-adfs==1.17.0'
(Pdb) b c:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py:122
Breakpoint 1 at c:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py:122
(Pdb) c
2019-08-23 11:01:31,202 [authenticator authenticator.py:authenticate] [8496-MainProcess] [1612-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
Password:
Sending request for authentication
Waiting for additional authentication
Going for aws roles
> c:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py(122)_retrieve_roles_page()
-> session.cookies.save(ignore_discard=True)
(Pdb) session.cookies
<LWPCookieJar[Cookie(version=0, name='hac|***|***', value='|***|***|***', port=None, port_specified=False, domain='api-ea1e82f9.duosecurity.com', domain_specified=False, domain_initial_dot=False, path='/', path_specified=True, secure=True, expires=253402300799, discard=False, comment=None, comment_url=None, rest={'httponly': None}, rfc2109=False), Cookie(version=0, name='trc|***|***', value='***', port=None, port_specified=False, domain='api-ea1e82f9.duosecurity.com', domain_specified=False, domain_initial_dot=False, path='/', path_specified=True, secure=True, expires=253402300799, discard=False, comment=None, comment_url=None, rest={'httponly': None}, rfc2109=False), Cookie(version=0, name='MSISAuth', value='***', port=None, port_specified=False, domain='sso.mydomain.net', domain_specified=False, domain_initial_dot=False, path='/adfs', path_specified=True, secure=True, expires=None, discard=True, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False), Cookie(version=0, name='MSISAuthenticated', value='***', port=None, port_specified=False, domain='sso.mydomain.net', domain_specified=False, domain_initial_dot=False, path='/adfs', path_specified=True, secure=True, expires=None, discard=True, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False), Cookie(version=0, name='MSISLoopDetectionCookie', value='***', port=None, port_specified=False, domain='sso.mydomain.net', domain_specified=False, domain_initial_dot=False, path='/adfs', path_specified=True, secure=True, expires=None, discard=True, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False), Cookie(version=0, name='SamlSession', value='***', port=None, port_specified=False, domain='sso.mydomain.net', domain_specified=False, domain_initial_dot=False, path='/adfs', path_specified=True, secure=True, expires=None, discard=True, comment=None, comment_url=None, rest={'HttpOnly': None}, rfc2109=False)]>
(Pdb) c
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\pdb.py", line 1701, in main
    pdb._runscript(mainpyfile)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\pdb.py", line 1570, in _runscript
    self.run(statement)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\bdb.py", line 585, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
  File "c:\aws-adfs\scripts\aws-adfs-script.py", line 11, in <module>
    load_entry_point('aws-adfs==1.17.0', 'console_scripts', 'aws-adfs')()
  File "C:\aws-adfs\lib\site-packages\click\core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "C:\aws-adfs\lib\site-packages\click\core.py", line 717, in main
    rv = self.invoke(ctx)
  File "C:\aws-adfs\lib\site-packages\click\core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "C:\aws-adfs\lib\site-packages\click\core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\aws-adfs\lib\site-packages\click\core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "C:\aws-adfs\lib\site-packages\aws_adfs\login.py", line 159, in login
    principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, config.adfs_user, password)
  File "C:\aws-adfs\lib\site-packages\aws_adfs\authenticator.py", line 33, in authenticate
    principal_roles, assertion, aws_session_duration = extract_strategy()
  File "C:\aws-adfs\lib\site-packages\aws_adfs\authenticator.py", line 113, in extract
    return duo_auth.extract(html_response, config.ssl_verification, session)
  File "C:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py", line 76, in extract
    '{}:{}'.format(auth_signature, _app(duo_request_signature)),
  File "C:\aws-adfs\lib\site-packages\aws_adfs\_duo_authenticator.py", line 122, in _retrieve_roles_page
    session.cookies.save(ignore_discard=True)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 1890, in save
    f.write(self.as_lwp_str(ignore_discard, ignore_expires))
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 1877, in as_lwp_str
    r.append("Set-Cookie3: %s" % lwp_cookie_str(cookie))
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 1838, in lwp_cookie_str
    time2isoz(float(cookie.expires))))
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py", line 101, in time2isoz
    dt = datetime.datetime.utcfromtimestamp(t)
OSError: [Errno 22] Invalid argument
Uncaught exception. Entering post mortem debugging
Running 'cont' or 'step' will restart the program
> c:\program files\windowsapps\pythonsoftwarefoundation.python.3.7_3.7.1264.0_x64__qbz5n2kfra8p0\lib\http\cookiejar.py(101)time2isoz()
-> dt = datetime.datetime.utcfromtimestamp(t)
(Pdb) t
253402300799.0
```

Duo uses the 253402300799 timestamp for its cookies `expires` dates which translates into 9999-12-31T23:59:59Z on Linux:

```
# python3
Python 3.7.3 (default, Apr  3 2019, 05:39:12)
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> t = 253402300799.0
>>> datetime.datetime.utcfromtimestamp(t)
datetime.datetime(9999, 12, 31, 23, 59, 59)
```

The same fails on Windows because the maximum date there is 3000-12-31T23:59:59Z with 64bit, and 2038-01-18T23:59:59Z with 32bit (cf. https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-localtime32-localtime64?view=vs-2019 and https://stackoverflow.com/a/50860754/316805):

```
PS C:\> python3
Python 3.7.4 (tags/v3.7.4:e09359112e, Jul  8 2019, 20:13:57) [MSC v.1916 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> t = 253402300799.0
>>> datetime.datetime.utcfromtimestamp(t)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
OSError: [Errno 22] Invalid argument
```

The issue does not happen with `MozillaCookieJar` because timestamps are stored without conversion.

For users upgrading, there will be no issue transitioning from one format to the other, old ADFS cookies are just ignored.

Tested with aws-adfs installed from this PR's branch:

```
PS C:\> & C:\aws-adfs\Scripts\pip install git+https://github.com/pdecat/aws-adfs@adfs_cookies_mozilla

PS C:\> cat C:\Users\pdeca\.aws\adfs_cookies
#LWP-Cookies-2.0

PS C:\> & C:\aws-adfs\Scripts\aws-adfs login --region=eu-west-1 --adfs-host=sso.mydomain.net --ssl-verification --session-duration=3600 --no-sspi
2019-08-23 11:16:47,043 [authenticator authenticator.py:authenticate] [8436-MainProcess] [6360-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
Password:
Sending request for authentication
Waiting for additional authentication
Going for aws roles

        Prepared ADFS configuration as follows:
            * AWS CLI profile                   : 'default'
            * AWS region                        : 'eu-west-1'
            * Output format                     : 'json'
            * SSL verification of ADFS Server   : 'ENABLED'
            * Selected role_arn                 : 'arn:aws:iam::***:role/AWS.ReadOnlyUsers'
            * ADFS Server                       : 'sso.mydomain.net'
            * ADFS Session Duration in seconds  : '28800'
            * Provider ID                       : 'urn:amazon:webservices'
            * S3 Signature Version              : 'None'
            * STS Session Duration in seconds   : '3600'

PS C:\> cat C:\Users\pdeca\.aws\adfs_cookies
# Netscape HTTP Cookie File
# http://curl.haxx.se/rfc/cookie_spec.html
# This is a generated file!  Do not edit.

api-ea1e82f9.duosecurity.com    FALSE   /       TRUE    253402300799    hac|***|***|***|***|***
api-ea1e82f9.duosecurity.com    FALSE   /       TRUE    253402300799    trc|***|***
sso.mydomain.net        FALSE   /adfs   TRUE            MSISAuth        ***
sso.mydomain.net        FALSE   /adfs   TRUE            MSISAuthenticated       ***
sso.mydomain.net        FALSE   /adfs   TRUE            MSISLoopDetectionCookie ***
sso.mydomain.net        FALSE   /adfs   TRUE            SamlSession     ***
```

# Test Environment Versions

- Windows 10 build 18965
- Python 3.7.4 from Microsoft Store