### PR TITLE
lxml 4.4.0 dropped support for python 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ tests_require = [
 ]
 
 install_requires = [
-    'lxml',
+    'lxml<4.4.0;python_version<"3.5"',
+    'lxml;python_version>="3.5"',
     'click',
     'botocore>=1.12.6',
     'boto3>=1.9.6',


### PR DESCRIPTION
Python 3.4 jobs fail at setup time no matter what: https://travis-ci.org/venth/aws-adfs/jobs/575755915

```
$ pip install --editable .
Obtaining file:///home/travis/build/venth/aws-adfs
Collecting lxml (from aws-adfs==1.17.0+2.g9784f83)
  Downloading https://files.pythonhosted.org/packages/e1/f5/5eb3b491958dcfdcfa5daae3c655ab59276bc216ca015e44743c9c220e9e/lxml-4.4.0.tar.gz (4.5MB)
    Complete output from command python setup.py egg_info:
    This lxml version requires Python 2.7, 3.5 or later.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-d_wprq64/lxml/
The command "pip install --editable ." failed and exited with 1 during .
Your build has been stopped.
```

Support for python 3.4 was removed in lxml 4.4.0: https://pypi.org/project/lxml/4.4.0/