### PR TITLE
Run tests with python 3.6, 3.7 and 3.8-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ python:
   - "2.7"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
+  - "3.6"
+  - "3.7"
+  - "3.8-dev" # 3.8 development branch
 before_install:
   - pip install --upgrade setuptools
   - pip install pytest


### PR DESCRIPTION
This adds 3.6, 3.7 and 3.8-dev to the list of tested python versions.

Python 3.4 jobs fail, fix is in #130.