### PR TITLE
Add options to trigger or not the default authentication method when U2F is available

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -517,6 +517,7 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
             }
         )
     else:
+        click.echo("Triggering default authentication method: '{}'".format(preferred_factor), err=True)
         response = session.post(
             prompt_for_url,
             verify=ssl_verification_enabled,

--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -33,7 +33,7 @@ _headers = {
 }
 
 
-def extract(html_response, ssl_verification_enabled, session):
+def extract(html_response, ssl_verification_enabled, u2f_trigger_default, session):
     """
     this strategy is based on description from: https://duo.com/docs/duoweb
     :param response: raw http response
@@ -75,22 +75,23 @@ def extract(html_response, ssl_verification_enabled, session):
             t.daemon = True
             t.start()
 
-        # Always trigger default authentication (call or push) concurrently to U2F
-        t = Thread(
-            target=_perform_authentication_transaction,
-            args=(
-                duo_host,
-                sid,
-                preferred_factor,
-                preferred_device,
-                False,
-                session,
-                ssl_verification_enabled,
-                rq,
+        if u2f_trigger_default or not u2f_supported:
+            # Trigger default authentication (call or push) concurrently to U2F
+            t = Thread(
+                target=_perform_authentication_transaction,
+                args=(
+                    duo_host,
+                    sid,
+                    preferred_factor,
+                    preferred_device,
+                    False,
+                    session,
+                    ssl_verification_enabled,
+                    rq,
+                )
             )
-        )
-        t.daemon = True
-        t.start()
+            t.daemon = True
+            t.start()
 
         # Wait for first response
         auth_signature = rq.get()

--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -20,7 +20,8 @@ def authenticate(config, username=None, password=None, assertfile=None):
         provider_id=config.provider_id,
         username=username,
         password=password,
-        sspi=config.sspi
+        sspi=config.sspi,
+        u2f_trigger_default=config.u2f_trigger_default,
     )
 
     assertion = None
@@ -110,7 +111,7 @@ def _strategy(response, config, session, assertfile=None):
 
     def _duo_extractor():
         def extract():
-            return duo_auth.extract(html_response, config.ssl_verification, session)
+            return duo_auth.extract(html_response, config.ssl_verification, config.u2f_trigger_default, session)
         return extract
 
     def _symantec_vip_extractor():

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -29,7 +29,8 @@ def fetch_html_encoded_roles(
         adfs_ca_bundle=None,
         username=None,
         password=None,
-        sspi=True
+        sspi=True,
+        u2f_trigger_default=True,
 ):
 
     # Support for Kerberos SSO on Windows via requests_negotiate_sspi

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -99,6 +99,11 @@ from . import role_chooser
     default=None,
     help='Whether or not to use Kerberos SSO authentication via SSPI, which may not work in some environments.',
 )
+@click.option(
+    '--u2f-trigger-default/--no-u2f-trigger-default',
+    default=None,
+    help='Whether or not to also trigger the default authentication method when U2F is available (only works with Duo for now).',
+)
 def login(
         profile,
         region,
@@ -116,7 +121,8 @@ def login(
         role_arn,
         session_duration,
         assertfile,
-        sspi
+        sspi,
+        u2f_trigger_default,
 ):
     """
     Authenticates an user with active directory credentials
@@ -131,7 +137,8 @@ def login(
         provider_id,
         s3_signature_version,
         session_duration,
-        sspi
+        sspi,
+        u2f_trigger_default,
     )
 
     _verification_checks(config)
@@ -253,6 +260,8 @@ def _emit_summary(config, session_duration):
             * Provider ID                       : '{}'
             * S3 Signature Version              : '{}'
             * STS Session Duration in seconds   : '{}'
+            * SSPI:                             : '{}'
+            * U2F and default method            : '{}'
         """.format(
             config.profile,
             config.region,
@@ -265,6 +274,7 @@ def _emit_summary(config, session_duration):
             config.s3_signature_version,
             config.session_duration,
             config.sspi,
+            config.u2f_trigger_default,
         )
     )
 
@@ -358,6 +368,7 @@ def _store(config, aws_session_token):
         config_file.set(profile, 'adfs_config.session_duration', config.session_duration)
         config_file.set(profile, 'adfs_config.provider_id', config.provider_id)
         config_file.set(profile, 'adfs_config.sspi', config.sspi)
+        config_file.set(profile, 'adfs_config.u2f_trigger_default', config.u2f_trigger_default)
 
     store_config(config.profile, config.aws_credentials_location, credentials_storer)
     if config.profile == 'default':

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -17,6 +17,7 @@ def get_prepared_config(
         s3_signature_version,
         session_duration,
         sspi,
+        u2f_trigger_default,
 ):
     """
     Prepares ADF configuration for login task.
@@ -38,6 +39,7 @@ def get_prepared_config(
     :param s3_signature_version: s3 signature version
     :param session_duration: AWS STS session duration (default 1 hour)
     :param sspi: Whether SSPI is enabled
+    :param u2f_trigger_default: Whether to also trigger the default authentication method when U2F is available
     """
     def default_if_none(value, default):
         return value if value is not None else default
@@ -60,6 +62,7 @@ def get_prepared_config(
     )
     adfs_config.session_duration = default_if_none(session_duration, adfs_config.session_duration)
     adfs_config.sspi = default_if_none(sspi, adfs_config.sspi)
+    adfs_config.u2f_trigger_default = default_if_none(u2f_trigger_default, adfs_config.u2f_trigger_default)
 
     return adfs_config
 
@@ -115,6 +118,9 @@ def create_adfs_default_config(profile):
 
     # Whether SSPI is enabled
     config.sspi = True
+
+    # Whether to also trigger the default authentication method when U2F is available
+    config.u2f_trigger_default = True
 
     return config
 
@@ -181,6 +187,9 @@ def _load_adfs_config_from_stored_profile(adfs_config, profile):
         adfs_config.sspi = ast.literal_eval(config.get_or(
             profile, 'adfs_config.sspi',
             str(adfs_config.sspi)))
+        adfs_config.u2f_trigger_default = ast.literal_eval(config.get_or(
+            profile, 'adfs_config.u2f_trigger_default',
+            str(adfs_config.u2f_trigger_default)))
 
     if profile == 'default':
         load_from_config(adfs_config.aws_config_location, profile, load_config)

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -298,6 +298,7 @@ class TestAuthenticator:
         self.irrelevant_config.adfs_ca_bundle = None
         self.irrelevant_config.provider_id = 'irrelevant provider identifier'
         self.irrelevant_config.sspi = True
+        self.irrelevant_config.u2f_trigger_default = True
 
         self.http_session = type('', (), {})()
         self.http_session.post = lambda *args, **kwargs: None

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -23,6 +23,7 @@ class TestConfigPreparation:
         default_s3_signature_version = None
         default_session_duration = 3600
         default_sspi = False
+        default_u2f_trigger_default = False
 
         # when configuration is prepared for not existing profile
         adfs_config = prepare.get_prepared_config(
@@ -36,6 +37,7 @@ class TestConfigPreparation:
             default_s3_signature_version,
             default_session_duration,
             default_sspi,
+            default_u2f_trigger_default,
         )
 
         # then resolved config contains defaults values
@@ -45,6 +47,8 @@ class TestConfigPreparation:
         assert default_adfs_host == adfs_config.adfs_host
         assert default_output_format == adfs_config.output_format
         assert default_session_duration == adfs_config.session_duration
+        assert default_sspi == adfs_config.sspi
+        assert default_u2f_trigger_default == adfs_config.u2f_trigger_default
 
     def test_when_the_profile_exists_but_lacks_ssl_verification_use_default_value(self):
         # given profile to read the configuration exists
@@ -61,6 +65,7 @@ class TestConfigPreparation:
         default_ssl_config = True
         default_adfs_ca_bundle = None
         default_sspi = True
+        default_u2f_trigger_default = True
         irrelevant_region = 'irrelevant_region'
         irrelevant_adfs_host = 'irrelevant_adfs_host'
         irrelevant_output_format = 'irrelevant_output_format'
@@ -79,10 +84,12 @@ class TestConfigPreparation:
             irrelevant_provider_id,
             irrelevant_s3_signature_version,
             irrelevant_session_duration,
-            default_sspi,            
+            default_sspi,
+            default_u2f_trigger_default,
         )
 
         # then resolved ssl verification holds the default value
         assert default_ssl_config == adfs_config.ssl_verification
         assert default_adfs_ca_bundle == adfs_config.adfs_ca_bundle
         assert default_sspi == adfs_config.sspi
+        assert default_u2f_trigger_default == adfs_config.u2f_trigger_default


### PR DESCRIPTION
This PR adds `--u2f-trigger-default`/`--no-u2f-trigger-default` options to determine whether to trigger the default authentication method when U2F is available (only works with Duo for now).

TODO:
- [ ] maybe find a better name for the CLI options