### PR TITLE
Pin fido2 dependency to < 0.8.0 as it is a breaking release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'boto3>=1.9.6',
     'requests[security]',
     'configparser',
-    'fido2',
+    'fido2<0.8.0',
 ]
 
 if system() == 'Windows':


### PR DESCRIPTION
Just published [fido2 0.8.0, quickly followed by 0.8.1](https://github.com/Yubico/python-fido2/releases/tag/0.8.1), is a breaking release.
Current implementation of U2F support in aws-adfs no longer works (did not investigate yet).

Until compatibility is achieved, pin that dependency to `< 0.8.0`.