### PR TITLE
U2F: fido2 v0.8.1 compatibility (U2FClient.sign timeout renamed to event)

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -403,7 +403,7 @@ def _u2f_sign(device, u2f_app_id, u2f_challenge, u2f_sign_requests, duo_host, si
                 u2f_app_id,
                 u2f_challenge,
                 u2f_sign_requests,
-                timeout=cancel
+                event=cancel
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ install_requires = [
     'boto3>=1.9.6',
     'requests[security]',
     'configparser',
-    'fido2<0.8.0',
+    'fido2>=0.8.1,<0.9.0',
 ]
 
 if system() == 'Windows':


### PR DESCRIPTION
This PR updates aws-adfs for compatibility with the recently released [fido2 0.8.1](https://github.com/Yubico/python-fido2/releases/tag/0.8.1), which is a breaking release.

The `timeout` parameter of `U2FClient.sign()` was renamed to `event` in fido2, see https://github.com/Yubico/python-fido2/commit/4c48977173fd32f70e61f518c7624558ffe54b9c#diff-570624f6ea4a71fef9e9cfcc8fe7b1a0R244

Supersedes https://github.com/venth/aws-adfs/pull/140