### PR TITLE
Kerberos support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ install_requires = [
 
 if system() == 'Windows':
     install_requires.append('requests-negotiate-sspi>=0.3.4')
+else:
+    install_requires.append('requests_kerberos')
 
 version = versioneer.get_version()
 


### PR DESCRIPTION
I was trying to use this project as a replacement for our own in-house code that integrates AWS/ADFS in a less portable way. One thing I noticed though is that your code doesn't seem to support Kerberos logins on Linux.

Looking through our code we used `requests_kerberos` to achieve this so I quickly hacked it into the codebase in place of `requests-negotiate-sspi` and I managed to get it work.

`requests_kerberos` does support Windows as well (using https://github.com/mongodb-labs/winkerberos) so in theory this could be required on all platforms, however I'm not sure if there's anything `requests-negotiate-sspi` does that `winkerberos` via `requests_kerberos` doesn't.

Obviously the PR is incomplete as it stands but what direction would you like to take here?

This would probably then fix #100.