### PR TITLE
Duo: support U2F with no preferred factor or device configured

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -118,6 +118,11 @@ def extract(html_response, ssl_verification_enabled, u2f_trigger_default, sessio
 
 
 def _perform_authentication_transaction(duo_host, sid, preferred_factor, preferred_device, use_u2f, session, ssl_verification_enabled, rq):
+    if (preferred_factor is None or preferred_device is None) and not use_u2f:
+        click.echo("No default authentication method configured.", err=True)
+        rq.put("cancelled")
+        return
+
     transaction_id = _begin_authentication_transaction(
         duo_host,
         sid,

--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -495,13 +495,13 @@ def _initiate_authentication(duo_host, duo_request_signature, roles_page_url, se
 def _preferred_factor(html_response):
     preferred_factor_query = './/input[@name="preferred_factor"]'
     element = html_response.find(preferred_factor_query)
-    return element.get('value')
+    return element is not None and element.get('value') or None
 
 
 def _preferred_device(html_response):
     preferred_device_query = './/input[@name="preferred_device"]'
     element = html_response.find(preferred_device_query)
-    return element.get('value')
+    return element is not None and element.get('value') or None
 
 
 def _u2f_supported(html_response):


### PR DESCRIPTION
This PR allows users without any preferred factor or device configured to still use U2F.

Without this change, the following error occurs in such a configuration:

```
$ aws-adfs --version
1.20.0
$ aws-adfs login
Sending request for authentication
Traceback (most recent call last):
  File "/usr/local/bin/aws-adfs", line 8, in <module>
    sys.exit(cli())
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/.local/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/user/.local/lib/python3.6/site-packages/aws_adfs/login.py", line 147, in login
    principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, assertfile=assertfile)
  File "/home/user/.local/lib/python3.6/site-packages/aws_adfs/authenticator.py", line 34, in authenticate
    principal_roles, assertion, aws_session_duration = extract_strategy()
  File "/home/user/.local/lib/python3.6/site-packages/aws_adfs/authenticator.py", line 114, in extract
    return duo_auth.extract(html_response, config.ssl_verification, config.u2f_trigger_default, session)
  File "/home/user/.local/lib/python3.6/site-packages/aws_adfs/_duo_authenticator.py", line 54, in extract
    ssl_verification_enabled
  File "/home/user/.local/lib/python3.6/site-packages/aws_adfs/_duo_authenticator.py", line 489, in _initiate_authentication
    preferred_factor = _preferred_factor(html_response)
  File "/home/user/.local/lib/python3.6/site-packages/aws_adfs/_duo_authenticator.py", line 498, in _preferred_factor
    return element.get('value')
AttributeError: 'NoneType' object has no attribute 'get'
```

With this change:

```
$ aws-adfs  login --u2f-trigger-default 
2019-12-16 12:26:25,517 [authenticator authenticator.py:authenticate] [8163-MainProcess] [140573867239232-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
Password: 
Sending request for authentication
Waiting for additional authentication
No default authentication method configured.
Activate your FIDO U2F authenticator now: 'CtapHidDevice(/dev/hidraw1)'
Got response from FIDO U2F authenticator: 'CtapHidDevice(/dev/hidraw1)'
Going for aws roles
...
```