### PR TITLE
Default SSPI to True on Windows only, False otherwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ aws-adfs integrates with:
     ```
     $ aws-adfs login --help
     Usage: aws-adfs login [OPTIONS]
-    
+
       Authenticates an user with active directory credentials
-    
+
     Options:
       --profile TEXT                  AWS cli profile that will be authenticated.
                                       After successful authentication just use:
@@ -233,8 +233,12 @@ aws-adfs integrates with:
       --assertfile TEXT               Use SAML assertion response from a local
                                       file
       --sspi / --no-sspi              Whether or not to use Kerberos SSO
-                                      authentication via SSPI, which may not work
-                                      in some environments.
+                                      authentication via SSPI (Windows only,
+                                      defaults to True).
+      --u2f-trigger-default / --no-u2f-trigger-default
+                                      Whether or not to also trigger the default
+                                      authentication method when U2F is available
+                                      (only works with Duo for now).
       --help                          Show this message and exit.
     ```
     ```

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -34,8 +34,8 @@ def fetch_html_encoded_roles(
         adfs_ca_bundle=None,
         username=None,
         password=None,
-        sspi=True,
-        u2f_trigger_default=True,
+        sspi=None,
+        u2f_trigger_default=None,
 ):
 
     # Support for Kerberos SSO on Windows via requests_negotiate_sspi

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -7,6 +7,7 @@ import click
 from botocore import client
 from os import environ
 import logging
+from platform import system
 import sys
 from . import authenticator
 from . import prepare
@@ -96,8 +97,8 @@ from . import role_chooser
 )
 @click.option(
     '--sspi/--no-sspi',
-    default=None,
-    help='Whether or not to use Kerberos SSO authentication via SSPI, which may not work in some environments.',
+    default=system() == 'Windows',
+    help='Whether or not to use Kerberos SSO authentication via SSPI (Windows only, defaults to True).',
 )
 @click.option(
     '--u2f-trigger-default/--no-u2f-trigger-default',

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -3,6 +3,7 @@ import configparser
 import os
 import botocore.session
 import botocore.exceptions
+from platform import system
 from types import MethodType
 
 
@@ -117,7 +118,7 @@ def create_adfs_default_config(profile):
     config.session_duration = int(3600)
 
     # Whether SSPI is enabled
-    config.sspi = True
+    config.sspi = system() == "Windows"
 
     # Whether to also trigger the default authentication method when U2F is available
     config.u2f_trigger_default = True


### PR DESCRIPTION
This PR changes the default value to the `--sspi` parameter to `False` on non-Windows systems as suggested by https://github.com/venth/aws-adfs/pull/144#issuecomment-567127634