### PR TITLE
Change `AuthMethod` parameter to `FormsAuthentication`

### DIFF
--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -84,7 +84,7 @@ def fetch_html_encoded_roles(
         data={
             'UserName': username,
             'Password': password,
-            'AuthMethod': provider_id
+            'AuthMethod': 'FormsAuthentication'
         }
 
     if adfs_ca_bundle:

--- a/test/test_fetch_html_encoded_roles.py
+++ b/test/test_fetch_html_encoded_roles.py
@@ -104,7 +104,7 @@ class TestFetchHtmlEncodedRoles:
             data={
                 'UserName': no_credentials_provided,
                 'Password': no_credentials_provided,
-                'AuthMethod': provider_id
+                'AuthMethod': 'FormsAuthentication'
             }
         )
 


### PR DESCRIPTION
The `AuthMethod` parameter of the signon page is set to the value of provider_id. Which is `urn:amazon:webservices` by default. After enabling ADFS DeviceAuthentication signons are failing.  Setting the `AuthMethod` parameter to `FormsAuthentication` fixes the issue. 
  