### PR TITLE
Fix username and password disclosure

### DIFF
--- a/aws_adfs/account_aliases_fetcher.py
+++ b/aws_adfs/account_aliases_fetcher.py
@@ -20,9 +20,6 @@ def account_aliases(session, username, password, auth_method, saml_response, con
         },
         auth=None,
         data={
-            'UserName': username,
-            'Password': password,
-            'AuthMethod': auth_method,
             'SAMLResponse': saml_response,
         }
     )


### PR DESCRIPTION
The account_aliases function was sending username and password to AWS.