### PR TITLE
Add support for non-public AWS regions (e.g. GovCloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,4 +375,5 @@ aws-adfs integrates with:
 * [rheemskerk](https://github.com/rheemskerk) for:
     * Fix username and password disclosure 
     * Fix authentication with cookies on non-windows system.
-    * Change `AuthMethod` parameter to `FormsAuthentication` 
+    * Change `AuthMethod` parameter to `FormsAuthentication`
+* [brodie11](https://github.com/brodie11) and [gregorydulin](https://github.com/gregorydulin) for: Add support for non-public AWS regions

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ aws-adfs integrates with:
     aws --profile=specified-profile s3 ls
     ```
 
+* login to your adfs host and fetch roles for AWS GovCloud (US)
+
+    ```
+    aws-adfs login --adfs-host=your-adfs-hostname --provider-id urn:amazon:webservices:govcloud --region us-gov-west-1
+    ```
+
+    and verification
+
+    ```
+    aws s3 ls
+    ```
+
 * login to your adfs host within ansible playbook
 
     ```

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -200,11 +200,19 @@ def login(
     try:
         session = botocore.session.get_session()
         session.set_config_variable('profile', config.profile)
-        conn = session.create_client('sts', config=client.Config(signature_version=botocore.UNSIGNED))
+        conn = session.create_client(
+            'sts',
+            region_name=region,
+            config=client.Config(signature_version=botocore.UNSIGNED),
+        )
     except botocore.exceptions.ProfileNotFound:
         logging.debug('Profile {} does not exist yet'.format(config.profile))
         session = botocore.session.get_session()
-        conn = session.create_client('sts', config=client.Config(signature_version=botocore.UNSIGNED))
+        conn = session.create_client(
+            'sts',
+            region_name=region,
+            config=client.Config(signature_version=botocore.UNSIGNED),
+        )
 
     aws_session_token = conn.assume_role_with_saml(
         RoleArn=config.role_arn,


### PR DESCRIPTION
Adds support for non-public AWS regions (e.g. GovCloud).

Tested against us-gov-west-1 and us-gov-east-1.

Fixes venth#102