### PR TITLE
Ask for authentication method if there is no default method set in Duo Security settings

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -119,9 +119,8 @@ def extract(html_response, ssl_verification_enabled, u2f_trigger_default, sessio
 
 def _perform_authentication_transaction(duo_host, sid, preferred_factor, preferred_device, use_u2f, session, ssl_verification_enabled, rq):
     if (preferred_factor is None or preferred_device is None) and not use_u2f:
-        click.echo("No default authentication method configured.", err=True)
-        rq.put("cancelled")
-        return
+        click.echo("No default authentication method configured.")
+        preferred_factor = click.prompt(text='Please enter your desired authentication method (Ex: Duo Push)', type=str)
 
     transaction_id = _begin_authentication_transaction(
         duo_host,
@@ -531,7 +530,7 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
             }
         )
     else:
-        click.echo("Triggering default authentication method: '{}'".format(preferred_factor), err=True)
+        click.echo("Triggering authentication method: '{}'".format(preferred_factor), err=True)
         response = session.post(
             prompt_for_url,
             verify=ssl_verification_enabled,


### PR DESCRIPTION
To avoid needing to set default Duo default authentication method, make aws-adfs tool ask for the method to use.

If Duo default authentication method is set (no change):
```
$ aws-adfs login --adfs-host="<host>" --session-duration 3600 
Sending request for authentication
Waiting for additional authentication
Triggering authentication method: 'Duo Push'
```

If Duo default authentication method is not set:
```
$ aws-adfs login --adfs-host="<host>" --session-duration 3600 
Username: 	
Password: 
Sending request for authentication
Waiting for additional authentication
No default authentication method configured.
Please enter your desired authentication method (Ex: Duo Push): Duo Push
Triggering authentication method: 'Duo Push'
```

If Duo default authentication method is not set, invalid method used:
```
$ aws-adfs login --adfs-host="<host>" --session-duration 3600 
Username: 
Password: 
Sending request for authentication
Waiting for additional authentication
No default authentication method configured.
Please enter your desired authentication method (Ex: Duo Push): Invalid
Triggering authentication method: 'Invalid'
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/aws_adfs/_duo_authenticator.py", line 132, in _perform_authentication_transaction
    ssl_verification_enabled
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/aws_adfs/_duo_authenticator.py", line 565, in _begin_authentication_transaction
    u'Cannot begin authentication process. The error response: {}'.format(response.text)
click.exceptions.ClickException: Cannot begin authentication process. The error response: {"stat": "FAIL", "message": "Unknown authentication method."}
```
