### PR TITLE
Always return the same number of values from _initiate_authentication()

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -480,13 +480,13 @@ def _initiate_authentication(duo_host, duo_request_signature, roles_page_url, se
                response.text))
 
     if response.status_code != 200 or response.url is None:
-        return (None, None, None), False
+        return (None, None, None, None), False
 
     o = urlparse(response.url)
     query = parse_qs(o.query)
 
     if 'sid' not in query:
-        return (None, None, None), False
+        return (None, None, None, None), False
 
     sid = query['sid']
     html_response = ET.fromstring(response.text, ET.HTMLParser())


### PR DESCRIPTION
This PR aims to resolve #157.

The issue was introduced by #127 : https://github.com/venth/aws-adfs/pull/127/files#diff-0584fbc181c07f609204d3aa5779348fR482