### PR TITLE
Feature credential process

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ aws-adfs integrates with:
     password = your_password
     ```
 
-* .aws/credentials profile for automatically refreshing credentials
+* .aws/config profile for automatically refreshing credentials
     ```
-    [example-role-ue1]
+    [profile example-role-ue1]
     credential-process=aws-adfs login --region=us-east-1 --role-arn=arn:aws:iam::1234567891234:role/example-role --adfs-host=adfs.example.com --stdout
     ```
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ aws-adfs integrates with:
     [profile example-role-ue1]
     credential_process=aws-adfs login --region=us-east-1 --role-arn=arn:aws:iam::1234567891234:role/example-role --adfs-host=adfs.example.com --stdout
     ```
+    Warning: see [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html) about security considerations to take when sourcing credentials with an external process.
 
 * help, help, help?
     ```

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ aws-adfs integrates with:
 * .aws/config profile for automatically refreshing credentials
     ```
     [profile example-role-ue1]
-    credential-process=aws-adfs login --region=us-east-1 --role-arn=arn:aws:iam::1234567891234:role/example-role --adfs-host=adfs.example.com --stdout
+    credential_process=aws-adfs login --region=us-east-1 --role-arn=arn:aws:iam::1234567891234:role/example-role --adfs-host=adfs.example.com --stdout
     ```
 
 * help, help, help?

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ aws-adfs integrates with:
     password = your_password
     ```
 
+* .aws/credentials profile for automatically refreshing credentials
+    ```
+    [example-role-ue1]
+    credential-process=aws-adfs login --region=us-east-1 --role-arn=arn:aws:iam::1234567891234:role/example-role --adfs-host=adfs.example.com --stdout
+    ```
+
 * help, help, help?
     ```
     $ aws-adfs --help

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -222,7 +222,7 @@ def login(
     )
 
     if stdout:
-        _emit_json(aws_session_token)
+        _emit_json(aws_session_token, aws_session_duration)
     elif printenv:
         _emit_summary(config, aws_session_duration)
         _print_environment_variables(aws_session_token,config)
@@ -231,12 +231,13 @@ def login(
         _emit_summary(config, aws_session_duration)
 
 
-def _emit_json(aws_session_token):
+def _emit_json(aws_session_token, aws_session_duration):
     click.echo(
-        u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}", "Version": 1}}""".format(
+        u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}", "Expiration": "{}", "Version": 1}}""".format(
             aws_session_token['Credentials']['AccessKeyId'],
             aws_session_token['Credentials']['SecretAccessKey'],
-            aws_session_token['Credentials']['SessionToken']
+            aws_session_token['Credentials']['SessionToken'],
+            (datetime.datetime.now()+datetime.timedelta(0,aws_session_duration)).isoformat()
         )
     )
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -9,7 +9,6 @@ from os import environ
 import logging
 from platform import system
 import sys
-import datetime
 from . import authenticator
 from . import prepare
 from . import role_chooser
@@ -223,7 +222,7 @@ def login(
     )
 
     if stdout:
-        _emit_json(aws_session_token, aws_session_duration)
+        _emit_json(aws_session_token)
     elif printenv:
         _emit_summary(config, aws_session_duration)
         _print_environment_variables(aws_session_token,config)
@@ -232,23 +231,13 @@ def login(
         _emit_summary(config, aws_session_duration)
 
 
-def _emit_json(aws_session_token, aws_session_duration):
-    class UTC(datetime.tzinfo):
-        def utcoffset(self, dt):
-            return datetime.timedelta(0)
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def dst(self, dt):
-            return datetime.timedelta(0)
-
+def _emit_json(aws_session_token):
     click.echo(
         u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}", "Expiration": "{}", "Version": 1}}""".format(
             aws_session_token['Credentials']['AccessKeyId'],
             aws_session_token['Credentials']['SecretAccessKey'],
             aws_session_token['Credentials']['SessionToken'],
-            (datetime.datetime.now(UTC())+datetime.timedelta(0,aws_session_duration)).isoformat()
+            aws_session_token['Credentials']['Expiration']
         )
     )
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -233,7 +233,7 @@ def login(
 
 
 def _emit_json(aws_session_token, aws_session_duration):
-    class UTC(tzinfo):
+    class UTC(datetime.tzinfo):
         def utcoffset(self, dt):
             return datetime.timedelta(0)
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -238,7 +238,7 @@ def _emit_json(aws_session_token):
         "AccessKeyId": aws_session_token['Credentials']['AccessKeyId'],
         "SecretAccessKey": aws_session_token['Credentials']['SecretAccessKey'],
         "SessionToken": aws_session_token['Credentials']['SessionToken'],
-        "Expiration": aws_session_token['Credentials']['Expiration']
+        "Expiration": aws_session_token['Credentials']['Expiration'].isoformat()
     }))
 
 def _print_environment_variables(aws_session_token,config):

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -232,6 +232,16 @@ def login(
 
 
 def _emit_json(aws_session_token, aws_session_duration):
+    class UTC(tzinfo):
+        def utcoffset(self, dt):
+            return datetime.timedelta(0)
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
     click.echo(
         u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}", "Expiration": "{}", "Version": 1}}""".format(
             aws_session_token['Credentials']['AccessKeyId'],

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -237,7 +237,7 @@ def _emit_json(aws_session_token, aws_session_duration):
             aws_session_token['Credentials']['AccessKeyId'],
             aws_session_token['Credentials']['SecretAccessKey'],
             aws_session_token['Credentials']['SessionToken'],
-            (datetime.datetime.now()+datetime.timedelta(0,aws_session_duration)).isoformat()
+            (datetime.datetime.now(UTC())+datetime.timedelta(0,aws_session_duration)).isoformat()
         )
     )
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -9,6 +9,7 @@ from os import environ
 import logging
 from platform import system
 import sys
+import datetime
 from . import authenticator
 from . import prepare
 from . import role_chooser

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -233,7 +233,7 @@ def login(
 
 def _emit_json(aws_session_token):
     click.echo(
-        u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}"}}""".format(
+        u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}", "Version": 1}}""".format(
             aws_session_token['Credentials']['AccessKeyId'],
             aws_session_token['Credentials']['SecretAccessKey'],
             aws_session_token['Credentials']['SessionToken']

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -9,6 +9,7 @@ from os import environ
 import logging
 from platform import system
 import sys
+import json
 from . import authenticator
 from . import prepare
 from . import role_chooser
@@ -232,14 +233,13 @@ def login(
 
 
 def _emit_json(aws_session_token):
-    click.echo(
-        u"""{{"AccessKeyId": "{}", "SecretAccessKey": "{}", "SessionToken": "{}", "Expiration": "{}", "Version": 1}}""".format(
-            aws_session_token['Credentials']['AccessKeyId'],
-            aws_session_token['Credentials']['SecretAccessKey'],
-            aws_session_token['Credentials']['SessionToken'],
-            aws_session_token['Credentials']['Expiration']
-        )
-    )
+    click.echo(json.dumps({
+        "Version": 1,
+        "AccessKeyId": aws_session_token['Credentials']['AccessKeyId'],
+        "SecretAccessKey": aws_session_token['Credentials']['SecretAccessKey'],
+        "SessionToken": aws_session_token['Credentials']['SessionToken'],
+        "Expiration": aws_session_token['Credentials']['Expiration']
+    }))
 
 def _print_environment_variables(aws_session_token,config):
     envcommand = "export"

--- a/test/test_credential_process_json.py
+++ b/test/test_credential_process_json.py
@@ -4,7 +4,7 @@ from aws_adfs import login
 from mock import patch
 
 
-class TestCredentialProcesJson:
+class TestCredentialProcessJson:
 
     def setup_method(self, method):
         self.access_key = 'AKIAIOSFODNN7EXAMPLE'

--- a/test/test_credential_process_json.py
+++ b/test/test_credential_process_json.py
@@ -26,7 +26,7 @@ class TestCredentialProcessJson:
         self.capture = value
 
     def test_json_is_valid_credential_process_format(self):
-        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
+        with patch('click.echo', side_effect = self._replace_echo):
             login._emit_json(self.aws_session_token)
 
             result = json.loads(self.capture)

--- a/test/test_credential_process_json.py
+++ b/test/test_credential_process_json.py
@@ -29,6 +29,7 @@ class TestCredentialProcessJson:
             login._emit_json(self.aws_session_token)
 
             result = json.loads(fake_out.call_args_list[0].args[0])
+            print(result)
 
             # Version is currently hardlocked at 1, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
             assert result["Version"] == 1

--- a/test/test_credential_process_json.py
+++ b/test/test_credential_process_json.py
@@ -1,0 +1,67 @@
+import datetime
+import json
+from aws_adfs import login
+from mock import patch
+
+
+class TestCredentialProcesJson:
+
+    def setup_method(self, method):
+        self.access_key = 'AKIAIOSFODNN7EXAMPLE'
+        self.secret_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'
+        self.session_token = 'AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7WZ0wq5VSXDvp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7ZD0u0iPPkUL64lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx3iSIlTJabIQwj2ICCR/oLxBA=='
+        self.expiration = '2020-06-30T20:17:02.439725+00:00'
+
+        self.aws_session_token = {
+            'Credentials': {
+                'AccessKeyId': self.access_key,
+                'SecretAccessKey': self.secret_key,
+                'SessionToken': self.session_token,
+                'Expiration': self.expiration
+            }
+        }
+
+    def _replace_echo(self, value):
+        return value
+
+    def test_json_includes_version_1(self):
+        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
+            login._emit_json(self.aws_session_token)
+
+            result = json.loads(fake_out.call_args_list[0].args[0])
+
+            # Version is currently hardlocked at 1, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+            assert result["Version"] == 1
+    
+    def test_json_has_access_key(self):
+        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
+            login._emit_json(self.aws_session_token)
+
+            result = json.loads(fake_out.call_args_list[0].args[0])
+
+            assert result["AccessKeyId"] == self.access_key
+
+    def test_json_has_secret_key(self):
+        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
+            login._emit_json(self.aws_session_token)
+
+            result = json.loads(fake_out.call_args_list[0].args[0])
+
+            assert result["SecretAccessKey"] == self.secret_key
+
+    def test_json_has_session_token(self):
+        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
+            login._emit_json(self.aws_session_token)
+
+            result = json.loads(fake_out.call_args_list[0].args[0])
+
+            assert result["SessionToken"] == self.session_token
+
+    def test_json_has_valid_expiration(self):
+        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
+            login._emit_json(self.aws_session_token)
+
+            result = json.loads(fake_out.call_args_list[0].args[0])
+
+            # Expiration must be a , see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+            assert result["Expiration"] == self.expiration

--- a/test/test_credential_process_json.py
+++ b/test/test_credential_process_json.py
@@ -24,7 +24,7 @@ class TestCredentialProcessJson:
     def _replace_echo(self, value):
         return value
 
-    def test_json_includes_version_1(self):
+    def test_json_is_valid_credential_process_format(self):
         with patch('click.echo', side_effect = self._replace_echo) as fake_out:
             login._emit_json(self.aws_session_token)
 
@@ -32,36 +32,8 @@ class TestCredentialProcessJson:
 
             # Version is currently hardlocked at 1, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
             assert result["Version"] == 1
-    
-    def test_json_has_access_key(self):
-        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
-            login._emit_json(self.aws_session_token)
-
-            result = json.loads(fake_out.call_args_list[0].args[0])
-
             assert result["AccessKeyId"] == self.access_key
-
-    def test_json_has_secret_key(self):
-        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
-            login._emit_json(self.aws_session_token)
-
-            result = json.loads(fake_out.call_args_list[0].args[0])
-
             assert result["SecretAccessKey"] == self.secret_key
-
-    def test_json_has_session_token(self):
-        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
-            login._emit_json(self.aws_session_token)
-
-            result = json.loads(fake_out.call_args_list[0].args[0])
-
             assert result["SessionToken"] == self.session_token
-
-    def test_json_has_valid_expiration(self):
-        with patch('click.echo', side_effect = self._replace_echo) as fake_out:
-            login._emit_json(self.aws_session_token)
-
-            result = json.loads(fake_out.call_args_list[0].args[0])
-
-            # Expiration must be a , see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
+            # Expiration must be ISO8601, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
             assert result["Expiration"] == self.expiration

--- a/test/test_credential_process_json.py
+++ b/test/test_credential_process_json.py
@@ -10,7 +10,7 @@ class TestCredentialProcessJson:
         self.access_key = 'AKIAIOSFODNN7EXAMPLE'
         self.secret_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'
         self.session_token = 'AQoDYXdzEPT//////////wEXAMPLEtc764bNrC9SAPBSM22wDOk4x4HIZ8j4FZTwdQWLWsKWHGBuFqwAeMicRXmxfpSPfIeoIYRqTflfKD8YUuwthAx7mSEI/qkPpKPi/kMcGdQrmGdeehM4IC1NtBmUpp2wUE8phUZampKsburEDy0KPkyQDYwT7WZ0wq5VSXDvp75YU9HFvlRd8Tx6q6fE8YQcHNVXAkiY9q6d+xo0rKwT38xVqr7ZD0u0iPPkUL64lIZbqBAz+scqKmlzm8FDrypNC9Yjc8fPOLn9FX9KSYvKTr4rvx3iSIlTJabIQwj2ICCR/oLxBA=='
-        self.expiration = '2020-06-30T20:17:02.439725+00:00'
+        self.expiration = datetime.datetime(2020,6,20)
 
         self.aws_session_token = {
             'Credentials': {
@@ -21,14 +21,15 @@ class TestCredentialProcessJson:
             }
         }
 
+    capture = ''
     def _replace_echo(self, value):
-        return value
+        self.capture = value
 
     def test_json_is_valid_credential_process_format(self):
         with patch('click.echo', side_effect = self._replace_echo) as fake_out:
             login._emit_json(self.aws_session_token)
 
-            result = json.loads(fake_out.call_args_list[0].args[0])
+            result = json.loads(self.capture)
             print(result)
 
             # Version is currently hardlocked at 1, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
@@ -37,4 +38,4 @@ class TestCredentialProcessJson:
             assert result["SecretAccessKey"] == self.secret_key
             assert result["SessionToken"] == self.session_token
             # Expiration must be ISO8601, see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html
-            assert result["Expiration"] == self.expiration
+            assert result["Expiration"] == self.expiration.isoformat()


### PR DESCRIPTION
Enable full support for the AWS Credential profile credential process as outlined in [Sourcing External Credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sourcing-external.html).

This Pull Request adds the following items to the JSON output format to support the credential process integration:

- Version: 1
- Expiration: _ISO8601 formatted timestamp of the expiration timestamp (current time + session duration)_

This could then be integrated into the AWS Credentials file as follows:
```
[example-role-ue1]
credential-process=aws-adfs login --region=us-east-1 --role-arn=arn:aws:iam::1234567891234:role/example-role --adfs-host=adfs.example.com --stdout
```

Closes #112 