### PR TITLE
Add python 3.9-dev support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,10 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# Visual Studio Code
+.vscode
+
 ### JetBrains template
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev" # 3.8 development branch
+  - "3.8"
+  - "3.9-dev" # 3.9 development branch
 before_install:
   - pip install --upgrade setuptools
   - pip install pytest


### PR DESCRIPTION
Replace python version 3.8-dev by 3.8 and add 3.9-dev.

We may want to drop 3.4 and maybe even 2.7 at some point, but there's no real gain right now. Maybe later if a cleanup or refactoring is considered at some point.

See https://devguide.python.org/#status-of-python-branches for officially supported python branches.