### PR TITLE
Add python 3.9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ ENV/
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# Visual Studio Code
+.vscode
+
 # User-specific stuff:
 .idea
 *.iml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8-dev" # 3.8 development branch
+  - "3.8"
+  - "3.9-dev" # 3.9 development branch
 before_install:
   - pip install --upgrade setuptools
   - pip install pytest

--- a/test/test_assertion_extractor.py
+++ b/test/test_assertion_extractor.py
@@ -5,6 +5,10 @@ import pytest
 
 from aws_adfs import roles_assertion_extractor
 
+try:
+  base64_encode = base64.encodebytes
+except:
+  base64_encode = base64.encodestring
 
 class TestAssertionExtractor:
 
@@ -75,7 +79,7 @@ class TestAssertionExtractor:
 </Assertion>
 </samlp:Response>'''
 
-        encoded_assertion = base64.encodestring(assertion.encode('utf-8')).decode('utf-8')
+        encoded_assertion = base64_encode(assertion.encode('utf-8')).decode('utf-8')
 
         return ET.fromstring(
             '''
@@ -109,7 +113,7 @@ class TestAssertionExtractor:
 </Assertion>
 </samlp:Response>'''
 
-        encoded_assertion = base64.encodestring(assertion.encode('utf-8')).decode('utf-8')
+        encoded_assertion = base64_encode(assertion.encode('utf-8')).decode('utf-8')
 
         return ET.fromstring(
             '''
@@ -146,7 +150,7 @@ class TestAssertionExtractor:
 </Assertion>
 </samlp:Response>'''.format(session_duration)
 
-        encoded_assertion = base64.encodestring(assertion.encode('utf-8')).decode('utf-8')
+        encoded_assertion = base64_encode(assertion.encode('utf-8')).decode('utf-8')
 
         return ET.fromstring(
             '''


### PR DESCRIPTION
Replace python version 3.8-dev by 3.8 and add 3.9-dev.

We may want to drop 3.4 and maybe even 2.7 at some point, but there's no real gain right now. Maybe later if a cleanup or refactoring is considered at some point.

See https://devguide.python.org/#status-of-python-branches for officially supported python branches.

Replaces #165 that was merged too soon: https://github.com/venth/aws-adfs/pull/165#issuecomment-653537135