### PR TITLE
Support Duo bypassing MFA requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -15,20 +15,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8]
+        python-version: [2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install libkrb5-dev
-      run: sudo apt-get install libkrb5-dev
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install aws-adfs['test']
-    - name: Test with pytest
-      run: |
-        pytest
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install libkrb5-dev
+        run: sudo apt-get install libkrb5-dev
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install aws-adfs['test']
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install libkrb5-dev
-        run: sudo apt-get install libkrb5-dev
+        run: sudo apt-get -y install libkrb5-dev
+      - name: Install libxml2-dev and libxslt1-dev for python 3.9
+        # Installing lxml from source is required for python 3.9 until a precompiled Wheel archive is available from PyPI, see https://pypi.org/project/lxml/#files
+        run: sudo apt-get -y install libxml2-dev libxslt1-dev
+        if: matrix.python-version == 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Duo can be configured to not request MFA when connections come from specific IP addresses.

When that occurs, it directly bypasses MFA and returns the authentication cookie.

Without this PR, the following error occurs when Duo bypasses MFA:

```
# aws-adfs login --profile=default --region=eu-west-1 --adfs-host=sso.mydomain.com --ssl-verification --session-duration 14400
Sending request for authentication
2020-07-21 13:29:26,882 [authenticator authenticator.py:authenticate] [569451-MainProcess] [139864343611200-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
Username: me@mydomain.com
Password: 
Sending request for authentication
2020-07-21 13:29:39,260 [authenticator authenticator.py:authenticate] [569451-MainProcess] [139864343611200-MainThread] - ERROR: Cannot extract saml assertion. Re-authentication needed?
This account does not have access to any roles
```

This has been tested by a coworker and myself from non-specific IP addresses for which MFA is required, and specific IP addresses for which MFA is **not** required.