### PR TITLE
Duo Fix: Your session has expired. Please try again

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -247,6 +247,7 @@ def _authentication_result(
             )
         )
     result_url = response.json()['response']['result_url']
+    sid = response.json()['response']["sid"]
     duo_result_response = _load_duo_result_url(duo_host, result_url, sid, session, ssl_verification_enabled)
     auth_signature = duo_result_response.json()['response']['cookie']
     return auth_signature


### PR DESCRIPTION
Fix for 
click.exceptions.ClickException: There was an issue when following the Duo result URL after authentication. The error response: {"stat": "FAIL", "message": "Your session has expired. Please try again."}