### PR TITLE
Automate PyPI publishing with poetry PEP517 built dists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 # This workflow will install Python dependencies and run tests with several versions of Python
+# When successful, packages are published to test.pypi.org and pypi.org (releases only)
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Build
@@ -19,18 +20,60 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install libkrb5-dev
         run: sudo apt-get -y install libkrb5-dev
+
       - name: Install aws-adfs and its dependencies
         run: |
           python -m pip install --upgrade pip
           pip install poetry==1.1.10
           poetry config experimental.new-installer false # New installer does not support python 3.10 yet, see https://github.com/python-poetry/poetry/issues/4210
           poetry install
+
       - name: Test with pytest
         run: |
           poetry run pytest
+
+      - name: Build a source archive
+        run: |
+          poetry build --format sdist
+        if: matrix.python-version == 3.9 # Only build source tarball once
+
+      - name: Build a wheel archive
+        run: |
+          poetry build --format wheel
+
+      - name: Publish package to TestPyPI
+        env:
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.test_pypi_password }}
+        run: |
+          poetry config repositories.testpypi https://test.pypi.org/legacy/
+          poetry publish --repository testpypi
+
+      - name: Check Version
+        id: check-version
+        run: |
+          [[ "$(poetry version --short)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || echo ::set-output name=prerelease::true
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: steps.check-version.outputs.prerelease == 'true'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pypi_password }}
+        run: poetry publish
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,12 @@ jobs:
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
           poetry publish --repository testpypi
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
       - name: Check Version
         id: check-version
         run: |
-          [[ "$(poetry version --short)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+          [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || echo ::set-output name=prerelease::true
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
@@ -76,4 +77,4 @@ jobs:
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pypi_password }}
         run: poetry publish
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && steps.check-version.outputs.prerelease != 'true'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "1.25.0-alpha.1"
+version = "1.25.0-alpha.2"
 description = "AWS Cli authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [


### PR DESCRIPTION
This PR automates the publishing of source and binary distribution packages to:
- https://test.pypi.org for all builds,
- https://pypi.org for tagged releases only.

Building those source and binary dists is now done via [poetry](https://github.com/python-poetry/poetry) [which implements](https://github.com/python-poetry/poetry-core) [PEP517](https://www.python.org/dev/peps/pep-0517/), e.g. locally:

```
pipx install poetry
poetry build
poetry publish
```

For more context, read:
* https://snarky.ca/what-the-heck-is-pyproject-toml/
* https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
* https://python-poetry.org/docs/cli/#build
* https://python-poetry.org/docs/cli/#publish