### PR TITLE
Fix issue 90: in some SAML assertions role_arn, provider_arn are in reverse order

### DIFF
--- a/aws_adfs/roles_assertion_extractor.py
+++ b/aws_adfs/roles_assertion_extractor.py
@@ -35,8 +35,13 @@ def extract(html):
     )
     aws_roles = [element.text.split(',') for element in raw_roles]
 
-    # Note the format of the attribute value is provider_arn, role_arn
-    principal_roles = [role for role in aws_roles if ':saml-provider/' in role[0]]
+    # Note the format of the attribute value is provider_arn, role_arn or in some cases role_arn, provider_arn
+    principal_roles = []
+    for role in aws_roles:
+        if ':saml-provider/' in role[0]:
+                principal_roles.append(role)
+        elif ':saml-provider/' in role[1]:
+                 principal_roles.append([role[1],role[0]])
 
     aws_session_duration = default_session_duration
     # Retrieve session duration


### PR DESCRIPTION
#90 I noticed that some configurations have a reverse order in role_arn and provider_arn into SAML Asssertion.
This results in returning zero roles.

By changing the way the role assertion extractor gets the role and provider it works in both configurations.
 