### PR TITLE
Compiling lxml from source is no longer needed with python 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install libkrb5-dev
         run: sudo apt-get -y install libkrb5-dev
-      - name: Install libxml2-dev and libxslt1-dev for python 3.9
-        # Installing lxml from source is required for python 3.9 until a precompiled Wheel archive is available from PyPI, see https://pypi.org/project/lxml/#files
-        run: sudo apt-get -y install libxml2-dev libxslt1-dev
-        if: matrix.python-version == 3.9
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Python 3.9 wheels are now available from PyPI: https://pypi.org/project/lxml/#files