### PR TITLE
Fix Github Actions build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install libkrb5-dev
         run: sudo apt-get -y install libkrb5-dev
-      - name: Install dependencies
+      - name: Install aws-adfs and its dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install aws-adfs['test']
+          pip install .['test']
       - name: Test with pytest
         run: |
           pytest


### PR DESCRIPTION
The Github Actions build job used to install aws-adfs from PyPI, no git (my bad :man_facepalming:).