### PR TITLE
Add `--username-password-command` to read username and password from the output of a shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,71 +217,59 @@ aws-adfs integrates with:
                                       After successful authentication just use:
                                       aws --profile <authenticated profile>
                                       <service> ...
-
       --region TEXT                   The default AWS region that this script will
                                       connect to for all API calls
-
       --ssl-verification / --no-ssl-verification
                                       SSL certificate verification: Whether or not
                                       strict certificate verification is done,
                                       False should only be used for dev/test
-
       --adfs-ca-bundle TEXT           Override CA bundle for SSL certificate
                                       verification for ADFS server only.
-
       --adfs-host TEXT                For the first time for a profile it has to
                                       be provided, next time for the same profile
                                       it will be loaded from the stored
                                       configuration
-
       --output-format [json|text|table]
                                       Output format used by aws cli
       --provider-id TEXT              Provider ID, e.g urn:amazon:webservices
                                       (optional)
-
       --s3-signature-version [s3v4]   s3 signature version: Identifies the version
                                       of AWS Signature to support for
                                       authenticated requests. Valid values: s3v4
-
+      --username-password-command TEXT
+                                      Read username and password from the output
+                                      of a shell command (expected JSON format:
+                                      `{"username": "myusername", "password":
+                                      "mypassword"}`)
       --env                           Read username, password from environment
                                       variables (username and password).
-
       --stdin                         Read username, password from standard input
                                       separated by a newline.
-
       --authfile TEXT                 Read username, password from a local file
                                       (optional)
-
       --stdout                        Print aws_session_token in json on stdout.
       --printenv                      Output commands to set AWS_ACCESS_KEY_ID,
                                       AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN,
                                       AWS_DEFAULT_REGION environmental variables
                                       instead of saving them to the aws
                                       configuration file.
-
       --role-arn TEXT                 Predefined role arn to selects, e.g. aws-
                                       adfs login --role-arn arn:aws:iam::123456789
                                       012:role/YourSpecialRole
-
       --session-duration INTEGER      Define the amount of seconds you want to
                                       establish your STS session, e.g. aws-adfs
                                       login --session-duration 3600
-
       --no-session-cache              Do not use AWS session cache in
                                       ~/.aws/adfs_cache/ directory.
-
       --assertfile TEXT               Use SAML assertion response from a local
                                       file
-
       --sspi / --no-sspi              Whether or not to use Kerberos SSO
                                       authentication via SSPI (Windows only,
                                       defaults to True).
-
       --u2f-trigger-default / --no-u2f-trigger-default
                                       Whether or not to also trigger the default
                                       authentication method when U2F is available
                                       (only works with Duo for now).
-
       --help                          Show this message and exit.
     ```
     ```
@@ -432,3 +420,4 @@ poetry run pytest
 * [johan1252](https://github.com/johan1252) for: Ask for authentication method if there is no default method set in Duo Security settings
 * [pdecat](https://github.com/pdecat) for: Always return the same number of values from _initiate_authentication()
 * [mikereinhold](https://github.com/mikereinhold) for: Feature credential process
+* [pdecat](https://github.com/pdecat) for: Add --username-password-command command line parameter

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -19,6 +19,7 @@ def get_prepared_config(
         session_duration,
         sspi,
         u2f_trigger_default,
+        username_password_command,
 ):
     """
     Prepares ADF configuration for login task.
@@ -41,6 +42,7 @@ def get_prepared_config(
     :param session_duration: AWS STS session duration (default 1 hour)
     :param sspi: Whether SSPI is enabled
     :param u2f_trigger_default: Whether to also trigger the default authentication method when U2F is available
+    :param username_password_command: The command used to retrieve username and password information
     """
     def default_if_none(value, default):
         return value if value is not None else default
@@ -64,6 +66,7 @@ def get_prepared_config(
     adfs_config.session_duration = default_if_none(session_duration, adfs_config.session_duration)
     adfs_config.sspi = default_if_none(sspi, adfs_config.sspi)
     adfs_config.u2f_trigger_default = default_if_none(u2f_trigger_default, adfs_config.u2f_trigger_default)
+    adfs_config.username_password_command = default_if_none(username_password_command, adfs_config.username_password_command)
 
     return adfs_config
 
@@ -122,6 +125,9 @@ def create_adfs_default_config(profile):
 
     # Whether to also trigger the default authentication method when U2F is available
     config.u2f_trigger_default = True
+
+    # The command used to retrieve username and password information
+    config.username_password_command = None
 
     return config
 
@@ -191,6 +197,7 @@ def _load_adfs_config_from_stored_profile(adfs_config, profile):
         adfs_config.u2f_trigger_default = ast.literal_eval(config.get_or(
             profile, 'adfs_config.u2f_trigger_default',
             str(adfs_config.u2f_trigger_default)))
+        adfs_config.username_password_command = config.get_or(profile, 'adfs_config.username_password_command', adfs_config.username_password_command)
 
     if profile == 'default':
         load_from_config(adfs_config.aws_config_location, profile, load_config)

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -24,6 +24,7 @@ class TestConfigPreparation:
         default_session_duration = 3600
         default_sspi = False
         default_u2f_trigger_default = False
+        default_username_password_command = None
 
         # when configuration is prepared for not existing profile
         adfs_config = prepare.get_prepared_config(
@@ -38,6 +39,7 @@ class TestConfigPreparation:
             default_session_duration,
             default_sspi,
             default_u2f_trigger_default,
+            default_username_password_command,
         )
 
         # then resolved config contains defaults values
@@ -49,6 +51,7 @@ class TestConfigPreparation:
         assert default_session_duration == adfs_config.session_duration
         assert default_sspi == adfs_config.sspi
         assert default_u2f_trigger_default == adfs_config.u2f_trigger_default
+        assert default_username_password_command == adfs_config.username_password_command
 
     def test_when_the_profile_exists_but_lacks_ssl_verification_use_default_value(self):
         # given profile to read the configuration exists
@@ -72,6 +75,7 @@ class TestConfigPreparation:
         irrelevant_provider_id = 'irrelevant_provider_id'
         irrelevant_s3_signature_version = 'irrelevant_s3_signature_version'
         irrelevant_session_duration = 'irrelevant_session_duration'
+        irrelevant_username_password_command = 'irrelevant_username_password_command'
         
         # when configuration is prepared for existing profile
         adfs_config = prepare.get_prepared_config(
@@ -86,6 +90,7 @@ class TestConfigPreparation:
             irrelevant_session_duration,
             default_sspi,
             default_u2f_trigger_default,
+            irrelevant_username_password_command,
         )
 
         # then resolved ssl verification holds the default value


### PR DESCRIPTION
This allows to login with:

```
aws-adfs login --username-password-command='echo "{\"username\": \"myusername\", \"password\": \"myusername\"}"' --region=eu-west-3 --adfs-host=myadfshost
```

This new method has the main advantage over the other methods (stdin, env, authfile) that if the cached ADFS cookie is still valid, the command used to retrieve username and password is not invoked.
This is mostly desired when that command is expensive and/or requires interaction (e.g. gopass with USB yubikey).

Concrete usage example with gopass:

```
aws-adfs login --username-password-command='echo "{\"username\": \"myusername\", \"password\": \"$(gopass show -o mygopasssecret)\"}"' --region=eu-west-3 --adfs-host=myadfshost
```

TODO:
- [x] rebase on master once #195 is merged
- [x] add unit tests
- [x] add doc