### PR TITLE
Print AWS web console sign-in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,14 @@ aws-adfs integrates with:
                                       AWS_DEFAULT_REGION environmental variables
                                       instead of saving them to the aws
                                       configuration file.
+      --print-console-signin-url      Output a URL that lets users who sign in to
+                                      your organization's network securely access
+                                      the AWS Management Console.
+      --console-role-arn TEXT         Role to assume for use in conjunction with
+                                      --print-console-signin-url
+      --console-external-id TEXT      External ID to pass in assume role for use
+                                      in conjunction with --print-console-signin-
+                                      url
       --role-arn TEXT                 Predefined role arn to selects, e.g. aws-
                                       adfs login --role-arn arn:aws:iam::123456789
                                       012:role/YourSpecialRole
@@ -420,4 +428,6 @@ poetry run pytest
 * [johan1252](https://github.com/johan1252) for: Ask for authentication method if there is no default method set in Duo Security settings
 * [pdecat](https://github.com/pdecat) for: Always return the same number of values from _initiate_authentication()
 * [mikereinhold](https://github.com/mikereinhold) for: Feature credential process
-* [pdecat](https://github.com/pdecat) for: Add --username-password-command command line parameter
+* [pdecat](https://github.com/pdecat) for:
+    * Add --username-password-command command line parameter
+    * Add --print-console-signin-url, --console-role-arn and --console-external-id command line parameters

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -5,6 +5,7 @@ import logging
 import os.path
 import subprocess
 import sys
+import urllib
 from datetime import datetime, timezone
 from os import environ
 from platform import system
@@ -13,6 +14,7 @@ import botocore
 import botocore.exceptions
 import botocore.session
 import click
+import requests
 from botocore import client
 
 from . import authenticator, helpers, prepare, role_chooser
@@ -91,6 +93,11 @@ from . import authenticator, helpers, prepare, role_chooser
     help='Output commands to set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_DEFAULT_REGION environmental variables instead of saving them to the aws configuration file.',
 )
 @click.option(
+    '--print-console-signin-url',
+    is_flag=True,
+    help='Output a URL that lets users who sign in to your organization\'s network securely access the AWS Management Console.',
+)
+@click.option(
     '--role-arn',
     help='Predefined role arn to selects, e.g. aws-adfs login --role-arn arn:aws:iam::123456789012:role/YourSpecialRole',
 )
@@ -133,6 +140,7 @@ def login(
     authfile,
     stdout,
     printenv,
+    print_console_signin_url,
     role_arn,
     session_duration,
     no_session_cache,
@@ -259,7 +267,9 @@ def login(
         _emit_json(aws_session_token)
     elif printenv:
         _emit_summary(config, aws_session_duration)
-        _print_environment_variables(aws_session_token,config)
+        _print_environment_variables(aws_session_token, config)
+    elif print_console_signin_url:
+        _print_console_signin_url(aws_session_token, adfs_host)
     else:
         _store(config, aws_session_token)
         _emit_summary(config, aws_session_duration)
@@ -275,7 +285,7 @@ def _emit_json(aws_session_token):
     }))
 
 
-def _print_environment_variables(aws_session_token,config):
+def _print_environment_variables(aws_session_token, config):
     envcommand = "export"
     if(sys.platform=="win32"):
         envcommand="set"
@@ -287,8 +297,41 @@ def _print_environment_variables(aws_session_token,config):
     click.echo(
         u"""{} AWS_SESSION_TOKEN={}""".format(envcommand,aws_session_token['Credentials']['SessionToken']))
     click.echo(
-        u"""{} AWS_DEFAULT_REGION={}""".format(envcommand,config.region))
+        u"""{} AWS_DEFAULT_REGION={}""".format(envcommand, config.region))
 
+
+def _print_console_signin_url(aws_session_token, adfs_host):
+    # The steps below come from https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
+
+    # Step 3: Format resulting temporary credentials into JSON
+    url_credentials = {}
+    url_credentials['sessionId'] = aws_session_token['Credentials']['AccessKeyId']
+    url_credentials['sessionKey'] = aws_session_token['Credentials']['SecretAccessKey']
+    url_credentials['sessionToken'] = aws_session_token['Credentials']['SessionToken']
+    json_string_with_temp_credentials = json.dumps(url_credentials)
+
+    # Step 4. Make request to AWS federation endpoint to get sign-in token. Construct the parameter string with
+    # the sign-in action request, a 12-hour session duration, and the JSON document with temporary credentials 
+    # as parameters.
+    request_parameters = "?Action=getSigninToken"
+    request_parameters += "&SessionDuration=43200"
+    request_parameters += "&Session=" + urllib.parse.quote_plus(json_string_with_temp_credentials)
+    request_url = "https://signin.aws.amazon.com/federation" + request_parameters
+    r = requests.get(request_url)
+    # Returns a JSON document with a single element named SigninToken.
+    signin_token = json.loads(r.text)
+
+    # Step 5: Create URL where users can use the sign-in token to sign in to
+    # the console. This URL must be used within 15 minutes after the
+    # sign-in token was issued.
+    request_parameters = "?Action=login"
+    request_parameters += "&Issuer=" + urllib.parse.quote_plus("https://" + adfs_host + "/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices")
+    request_parameters += "&Destination=" + urllib.parse.quote_plus("https://console.aws.amazon.com/")
+    request_parameters += "&SigninToken=" + signin_token["SigninToken"]
+    request_url = "https://signin.aws.amazon.com/federation" + request_parameters
+
+    # Send final URL to stdout
+    click.echo("""\nAWS web console signin URL:\n\n{}""".format(request_url))
 
 def _emit_summary(config, session_duration):
     click.echo(

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,8 +21,24 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "boto3"
+version = "1.20.50"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.23.50,<1.24.0"
+jmespath = ">=0.7.1,<1.0.0"
+s3transfer = ">=0.5.0,<0.6.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
 name = "botocore"
-version = "1.23.43"
+version = "1.23.50"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -401,6 +417,20 @@ requests = ">=2.0"
 dev = ["setuptools-version-command"]
 
 [[package]]
+name = "s3transfer"
+version = "0.5.1"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -460,7 +490,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "906b6f8e325a908416badffbe5e0b36a6e645f987b15605514a604908037e122"
+content-hash = "eefbe01ae6176c012e1ba9b159acf18611317cb7fedb7676bca876f371ffb6fa"
 
 [metadata.files]
 atomicwrites = [
@@ -471,9 +501,13 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
+boto3 = [
+    {file = "boto3-1.20.50-py3-none-any.whl", hash = "sha256:87994c3753ef386189a222556eaf7cb1ef63432d516b4344c7b2899ce544ad2a"},
+    {file = "boto3-1.20.50.tar.gz", hash = "sha256:c62362e3105c918272a95c9f4881587c3a3c68aa5fedcd322313def3688c9f7b"},
+]
 botocore = [
-    {file = "botocore-1.23.43-py3-none-any.whl", hash = "sha256:22c88a653a026439f2e9b0ade154fafe0eaaaea3fee6e080102d90ec4271284e"},
-    {file = "botocore-1.23.43.tar.gz", hash = "sha256:f8c60dff90a7aea7f84908f0e4e778890d4f08c883d2da111c15c10d7c199102"},
+    {file = "botocore-1.23.50-py3-none-any.whl", hash = "sha256:aa953d9767ff99a7aa35dde770a1405c8877cef9caf280859b94104483b8368d"},
+    {file = "botocore-1.23.50.tar.gz", hash = "sha256:109d9a200f70268d5429423fd8052f6fed5e041853d6621081692ea5ad7f70c7"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -777,6 +811,10 @@ requests-kerberos = [
 ]
 requests-negotiate-sspi = [
     {file = "requests_negotiate_sspi-0.5.2-py2.py3-none-any.whl", hash = "sha256:84ca9e81cfd3f2bd5eede5f8eddec1d5b58d957efac5e7fc078a3b323d296b77"},
+]
+s3transfer = [
+    {file = "s3transfer-0.5.1-py3-none-any.whl", hash = "sha256:25c140f5c66aa79e1ac60be50dcd45ddc59e83895f062a3aab263b870102911f"},
+    {file = "s3transfer-0.5.1.tar.gz", hash = "sha256:69d264d3e760e569b78aaa0f22c97e955891cd22e32b10c51f784eeda4d9d10a"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ requests-kerberos = [
 requests-negotiate-sspi= [
     { version = ">=0.3.4", markers = "platform_system == 'Windows'" },
 ]
+boto3 = "^1.20.50"
 
 [tool.poetry.dev-dependencies]
 coverage = "<4"


### PR DESCRIPTION
This PoC implements the generation of AWS web console sign-in URLs as described in https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html

Note: maybe this should not be integrated in aws-adfs but rather make it in another independent tool.

Resolves #143.

TODO:
- [x] rebase on master once #195 and #196 are merged
- [ ] add unit tests
- [x] add doc