### PR TITLE
Depend on requests-negotiate-sspi on Windows. On other platforms, depend on requests-kerberos and pykerberos.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,12 @@
-# This workflow will install Python dependencies and run tests with several versions of Python
+# This workflow will install Python dependencies and run tests with several versions of Python on MacOS, Ubuntu and Windows
 # When successful, packages are published to test.pypi.org and pypi.org (releases only)
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Build
+
+env:
+  PYTHON_VERSION: 3.9
+  POETRY_VERSION: 1.1.10
 
 on:
   push:
@@ -11,7 +15,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  test-and-package-wheel-archive:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,25 +35,75 @@ jobs:
         run: sudo apt-get -y install libkrb5-dev
         if: matrix.os == 'ubuntu-latest'
 
+      - name: Install poetry ${{ env.POETRY_VERSION }}
+        run: |
+          pip install poetry==${{ env.POETRY_VERSION }}
+          poetry config experimental.new-installer false # New installer does not support python 3.10 yet, see https://github.com/python-poetry/poetry/issues/4210
+
       - name: Install aws-adfs and its dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install poetry==1.1.10
-          poetry config experimental.new-installer false # New installer does not support python 3.10 yet, see https://github.com/python-poetry/poetry/issues/4210
           poetry install
 
       - name: Test with pytest
         run: |
           poetry run pytest
 
-      - name: Build a source archive
-        run: |
-          poetry build --format sdist
-        if: matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest' # Only build source tarball once
-
       - name: Build a wheel archive
         run: |
           poetry build --format wheel
+
+      - name: Upload wheel archive
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            dist
+
+  package-source-archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install poetry ${{ env.POETRY_VERSION }}
+        run: |
+          pip install poetry==${{ env.POETRY_VERSION }}
+
+      - name: Build a source archive
+        run: |
+          poetry build --format sdist
+
+      - name: Upload source archive
+        uses: actions/upload-artifact@v2
+        with:
+          path: |
+            dist
+
+  publish:
+    needs:
+      - test-and-package-wheel-archive
+      - package-source-archive
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') # Only publish tagged releases
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download all workflow source and wheel archives
+        uses: actions/download-artifact@v2
+        with:
+          path: dist
+
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install poetry ${{ env.POETRY_VERSION }}
+        run: |
+          pip install poetry==${{ env.POETRY_VERSION }}
 
       - name: Publish package to TestPyPI
         env:
@@ -57,14 +111,12 @@ jobs:
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
           poetry publish --repository testpypi
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
       - name: Check Version
         id: check-version
         run: |
           [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
             || echo ::set-output name=prerelease::true
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
       - name: Create Release
         uses: ncipollo/release-action@v1
@@ -73,10 +125,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           prerelease: steps.check-version.outputs.prerelease == 'true'
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
       - name: Publish to PyPI
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.pypi_password }}
         run: poetry publish
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && steps.check-version.outputs.prerelease != 'true'
+        if: steps.check-version.outputs.prerelease != 'true' # Only publish final releases to PyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        exclude:
+          # Python 3.10-dev on Windows is excluded for now as this combination:
+          # - has no pywin32 wheel available yet, see https://github.com/mhammond/pywin32/issues/1588 and https://pypi.org/project/pywin32/301/#files
+          # - has no lxml wheel available yet, and building lxml 4.6.3 fails, even with Cython 0.29.24 installed
+          - os: windows-latest
+            python-version: 3.10-dev
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build a source archive
         run: |
           poetry build --format sdist
-        if: matrix.python-version == 3.9 # Only build source tarball once
+        if: matrix.python-version == 3.9 && matrix.os == 'ubuntu-latest' # Only build source tarball once
 
       - name: Build a wheel archive
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Install libkrb5-dev
         run: sudo apt-get -y install libkrb5-dev
+        if: matrix.os == 'ubuntu-latest'
 
       - name: Install aws-adfs and its dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   test-and-package-wheel-archive:
+    name: Build wheel (${{ matrix.python-version }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -59,6 +60,7 @@ jobs:
             dist
 
   package-source-archive:
+    name: Package source archive
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -83,6 +85,7 @@ jobs:
             dist
 
   publish:
+    name: Publish source and wheel archives
     needs:
       - test-and-package-wheel-archive
       - package-source-archive

--- a/poetry.lock
+++ b/poetry.lock
@@ -155,6 +155,23 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "importlib-metadata"
+version = "4.8.1"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+
+[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -279,6 +296,17 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "pypiwin32"
+version = "223"
+description = ""
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pywin32 = ">=223"
+
+[[package]]
 name = "pytest"
 version = "6.1.2"
 description = "pytest: simple powerful testing with Python"
@@ -336,6 +364,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "pywin32"
+version = "301"
+description = "Python for Window Extensions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "requests"
 version = "2.25.1"
 description = "Python HTTP for Humans."
@@ -368,6 +404,21 @@ requests = ">=1.1.0"
 winkerberos = {version = ">=0.5.0", markers = "sys_platform == \"win32\""}
 
 [[package]]
+name = "requests-negotiate-sspi"
+version = "0.5.2"
+description = "This package allows for Single-Sign On HTTP Negotiate authentication using the requests library on Windows."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pypiwin32 = ">=223"
+requests = ">=2.0"
+
+[package.extras]
+dev = ["setuptools-version-command"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -382,6 +433,14 @@ description = "Python Library for Tom's Obvious, Minimal Language"
 category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "typing-extensions"
+version = "3.10.0.2"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "uhid-freebsd"
@@ -424,10 +483,22 @@ python-versions = ">=2.7"
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
+[[package]]
+name = "zipp"
+version = "3.6.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.5"
-content-hash = "bb850ffdc79d1af03a418bdf0205bdac141de76a7053bd283893f3af59a41b50"
+content-hash = "dcbcc8729e2e98a2eb822fe7b0b73be647dc0a0d3c21c34dc45097d39447ae7d"
 
 [metadata.files]
 atomicwrites = [
@@ -560,6 +631,8 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-2.1.1-py2.py3-none-any.whl", hash = "sha256:c2d6341ff566f609e89a2acb2db190e5e1d23d5409d6cc8d2fe34d72443876d4"},
     {file = "importlib_metadata-2.1.1.tar.gz", hash = "sha256:b8de9eff2b35fb037368f28a7df1df4e6436f578fa74423505b6c6a778d5b5dd"},
+    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
+    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -650,6 +723,10 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
+pypiwin32 = [
+    {file = "pypiwin32-223-py3-none-any.whl", hash = "sha256:67adf399debc1d5d14dffc1ab5acacb800da569754fafdc576b2a039485aa775"},
+    {file = "pypiwin32-223.tar.gz", hash = "sha256:71be40c1fbd28594214ecaecb58e7aa8b708eabfa0125c8a109ebd51edbd776a"},
+]
 pytest = [
     {file = "pytest-6.1.2-py3-none-any.whl", hash = "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe"},
     {file = "pytest-6.1.2.tar.gz", hash = "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"},
@@ -660,6 +737,18 @@ python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
+pywin32 = [
+    {file = "pywin32-301-cp35-cp35m-win32.whl", hash = "sha256:93367c96e3a76dfe5003d8291ae16454ca7d84bb24d721e0b74a07610b7be4a7"},
+    {file = "pywin32-301-cp35-cp35m-win_amd64.whl", hash = "sha256:9635df6998a70282bd36e7ac2a5cef9ead1627b0a63b17c731312c7a0daebb72"},
+    {file = "pywin32-301-cp36-cp36m-win32.whl", hash = "sha256:c866f04a182a8cb9b7855de065113bbd2e40524f570db73ef1ee99ff0a5cc2f0"},
+    {file = "pywin32-301-cp36-cp36m-win_amd64.whl", hash = "sha256:dafa18e95bf2a92f298fe9c582b0e205aca45c55f989937c52c454ce65b93c78"},
+    {file = "pywin32-301-cp37-cp37m-win32.whl", hash = "sha256:98f62a3f60aa64894a290fb7494bfa0bfa0a199e9e052e1ac293b2ad3cd2818b"},
+    {file = "pywin32-301-cp37-cp37m-win_amd64.whl", hash = "sha256:fb3b4933e0382ba49305cc6cd3fb18525df7fd96aa434de19ce0878133bf8e4a"},
+    {file = "pywin32-301-cp38-cp38-win32.whl", hash = "sha256:88981dd3cfb07432625b180f49bf4e179fb8cbb5704cd512e38dd63636af7a17"},
+    {file = "pywin32-301-cp38-cp38-win_amd64.whl", hash = "sha256:8c9d33968aa7fcddf44e47750e18f3d034c3e443a707688a008a2e52bbef7e96"},
+    {file = "pywin32-301-cp39-cp39-win32.whl", hash = "sha256:595d397df65f1b2e0beaca63a883ae6d8b6df1cdea85c16ae85f6d2e648133fe"},
+    {file = "pywin32-301-cp39-cp39-win_amd64.whl", hash = "sha256:87604a4087434cd814ad8973bd47d6524bd1fa9e971ce428e76b62a5e0860fdf"},
+]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},
     {file = "requests-2.25.1.tar.gz", hash = "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804"},
@@ -668,6 +757,9 @@ requests-kerberos = [
     {file = "requests-kerberos-0.12.0.tar.gz", hash = "sha256:9d21f15241c53c2ad47e813138b9aee4b9acdd04b82048c4388ade15f40a52fd"},
     {file = "requests_kerberos-0.12.0-py2.py3-none-any.whl", hash = "sha256:5733abc0b6524815f6fc72d5c0ec9f3fb89137b852adea2a461c45931f5675e0"},
 ]
+requests-negotiate-sspi = [
+    {file = "requests_negotiate_sspi-0.5.2-py2.py3-none-any.whl", hash = "sha256:84ca9e81cfd3f2bd5eede5f8eddec1d5b58d957efac5e7fc078a3b323d296b77"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -675,6 +767,11 @@ six = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
+    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
+    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 uhid-freebsd = [
     {file = "uhid-freebsd-1.2.2.tar.gz", hash = "sha256:3670374111e9cde795323992809c1299c95c46e96b9bd888c3b340a4e1e733bc"},
@@ -703,4 +800,6 @@ winkerberos = [
 zipp = [
     {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
     {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
+    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,12 @@ configparser = "*"
 fido2 = "^0.8.1" # fido2 0.9.0 is a breaking release
 lxml = "*"
 requests = "*"
-requests-kerberos = "*"
+requests-kerberos = [
+    { version = "*", markers = "platform_system != 'Windows'" },
+]
+requests-negotiate-sspi= [
+    { version = ">=0.3.4", markers = "platform_system == 'Windows'" },
+]
 
 [tool.poetry.dev-dependencies]
 coverage = "<4"


### PR DESCRIPTION
This reinstates the behavior from `setup.py` before [migration to poetry](#194):

```
if system() == 'Windows':
    install_requires.append('requests-negotiate-sspi>=0.3.4')
else:
    install_requires.append('requests_kerberos')
```

https://github.com/venth/aws-adfs/pull/144/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R29-R32
