### PR TITLE
Switch from U2F to WebAuthn for DUO authentication

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for poetry
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
           generateReleaseNotes: true
-          prerelease: steps.check-version.outputs.prerelease == 'true'
+          prerelease: ${{ steps.check-version.outputs.prerelease == 'true' }}
 
       - name: Publish to PyPI
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,7 @@ jobs:
           artifacts: "dist/*"
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: false
+          generateReleaseNotes: true
           prerelease: steps.check-version.outputs.prerelease == 'true'
 
       - name: Publish to PyPI

--- a/README.md
+++ b/README.md
@@ -274,10 +274,6 @@ aws-adfs integrates with:
       --sspi / --no-sspi              Whether or not to use Kerberos SSO
                                       authentication via SSPI (Windows only,
                                       defaults to True).
-      --webauthn-trigger-default / --no-webauthn-trigger-default
-                                      Whether or not to also trigger the default
-                                      authentication method when WebAuthn is
-                                      available (only works with Duo for now).
       --help                          Show this message and exit.
     ```
     ```
@@ -433,3 +429,4 @@ poetry run pytest
     * Add --print-console-signin-url, --console-role-arn and --console-external-id command line parameters
     * Update to fido2 v0.9.3
     * Replace U2F by WebAuthn following Duo move from the former to the latter (compatible with FIDO U2F (CTAP1) by FIDO2 (CTAP2) authenticators)
+    * Remove --u2f-trigger-default/--no-u2f-trigger-default command line parameters

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ As of version 0.2.0, this tool acts on the 'default' profile unless an alternate
 ### MFA integration
 
 aws-adfs integrates with:
-* [duo security](https://duo.com) MFA provider with support for FIDO U2F hardware authenticator
+* [duo security](https://duo.com) MFA provider with support for FIDO U2F (CTAP1) / FIDO2 (CTAP2) hardware authenticators
 * [Symantec VIP](https://vip.symantec.com/) MFA provider
 * [RSA SecurID](https://www.rsa.com/) MFA provider
 
@@ -274,10 +274,10 @@ aws-adfs integrates with:
       --sspi / --no-sspi              Whether or not to use Kerberos SSO
                                       authentication via SSPI (Windows only,
                                       defaults to True).
-      --u2f-trigger-default / --no-u2f-trigger-default
+      --webauthn-trigger-default / --no-webauthn-trigger-default
                                       Whether or not to also trigger the default
-                                      authentication method when U2F is available
-                                      (only works with Duo for now).
+                                      authentication method when WebAuthn is
+                                      available (only works with Duo for now).
       --help                          Show this message and exit.
     ```
     ```
@@ -299,7 +299,7 @@ aws-adfs integrates with:
 
     Please setup preferred auth method in duo-security settings (settings' -> 'My Settings & Devices').
 
-* USB FIDO U2F does not work in Windows Subsystem for Linux (WSL)
+* USB FIDO2 does not work in Windows Subsystem for Linux (WSL)
 
     `OSError: [Errno 2] No such file or directory: '/sys/class/hidraw'`
 
@@ -310,9 +310,9 @@ aws-adfs integrates with:
     export AWS_SHARED_CREDENTIALS_FILE=/mnt/c/Users/username/.aws/credentials
     ```
 
-*  FIDO U2F devices are not detected on Windows 10 build 1903 or newer
+*  FIDO2 devices are not detected on Windows 10 build 1903 or newer
 
-    Running `aws-adfs` as Administrator is required since Windows 10 build 1903 to access FIDO U2F devices, cf. https://github.com/Yubico/python-fido2/issues/55)
+    Running `aws-adfs` as Administrator is required since Windows 10 build 1903 to access FIDO2 devices, cf. https://github.com/Yubico/python-fido2/issues/55)
 
 * in cases of trouble with lxml please install
 
@@ -431,3 +431,5 @@ poetry run pytest
 * [pdecat](https://github.com/pdecat) for:
     * Add --username-password-command command line parameter
     * Add --print-console-signin-url, --console-role-arn and --console-external-id command line parameters
+    * Update to fido2 v0.9.3
+    * Replace U2F by WebAuthn following Duo move from the former to the latter (compatible with FIDO U2F (CTAP1) by FIDO2 (CTAP2) authenticators)

--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -1,7 +1,9 @@
+import base64
+import binascii
 import click
 import lxml.etree as ET
 
-from fido2.client import ClientData, ClientError, U2fClient
+from fido2.client import ClientData, ClientError, Fido2Client
 from fido2.hid import CtapHidDevice
 try:
     from fido2.pcsc import CtapPcscDevice
@@ -13,6 +15,8 @@ import json
 import re
 
 from threading import Event, Thread
+
+from .helpers import trace_http_request
 
 try:
     # Python 3
@@ -33,7 +37,7 @@ _headers = {
 }
 
 
-def extract(html_response, ssl_verification_enabled, u2f_trigger_default, session):
+def extract(html_response, ssl_verification_enabled, webauthn_trigger_default, session):
     """
     this strategy is based on description from: https://duo.com/docs/duoweb
     :param response: raw http response
@@ -46,7 +50,7 @@ def extract(html_response, ssl_verification_enabled, u2f_trigger_default, sessio
     roles_page_url = _action_url_on_validation_success(html_response)
 
     click.echo("Sending request for authentication", err=True)
-    (sid, preferred_factor, preferred_device, u2f_supported, auth_signature), initiated = _initiate_authentication(
+    (sid, preferred_factor, preferred_device, webauthn_supported, auth_signature), initiated = _initiate_authentication(
         duo_host,
         duo_request_signature,
         roles_page_url,
@@ -59,8 +63,8 @@ def extract(html_response, ssl_verification_enabled, u2f_trigger_default, sessio
 
             rq = queue.Queue()
             auth_count = 0
-            if u2f_supported:
-                # Trigger U2F authentication
+            if webauthn_supported:
+                # Trigger FIDO U2F / FIDO2 authentication
                 auth_count += 1
                 t = Thread(
                     target=_perform_authentication_transaction,
@@ -78,8 +82,8 @@ def extract(html_response, ssl_verification_enabled, u2f_trigger_default, sessio
                 t.daemon = True
                 t.start()
 
-            if u2f_trigger_default or not u2f_supported:
-                # Trigger default authentication (call or push) concurrently to U2F
+            if webauthn_trigger_default or not webauthn_supported:
+                # Trigger default authentication (call or push) concurrently to FIDO U2F / FIDO2
                 auth_count += 1
                 t = Thread(
                     target=_perform_authentication_transaction,
@@ -118,8 +122,8 @@ def extract(html_response, ssl_verification_enabled, u2f_trigger_default, sessio
     return None, None, None
 
 
-def _perform_authentication_transaction(duo_host, sid, preferred_factor, preferred_device, use_u2f, session, ssl_verification_enabled, rq):
-    if (preferred_factor is None or preferred_device is None) and not use_u2f:
+def _perform_authentication_transaction(duo_host, sid, preferred_factor, preferred_device, use_webauthn, session, ssl_verification_enabled, rq):
+    if (preferred_factor is None or preferred_device is None) and not use_webauthn:
         click.echo("No default authentication method configured.")
         preferred_factor = click.prompt(text='Please enter your desired authentication method (Ex: Duo Push)', type=str)
 
@@ -128,7 +132,7 @@ def _perform_authentication_transaction(duo_host, sid, preferred_factor, preferr
         sid,
         preferred_factor,
         preferred_device,
-        use_u2f,
+        use_webauthn,
         session,
         ssl_verification_enabled
     )
@@ -161,26 +165,19 @@ def _retrieve_roles_page(roles_page_url, context, session, ssl_verification_enab
     logging.debug('context: {}'.format(context))
     logging.debug('sig_response: {}'.format(signed_response))
 
+    data = {
+        'AuthMethod': 'DuoAdfsAdapter',
+        'Context': context,
+        'sig_response': signed_response,
+    }
     response = session.post(
         roles_page_url,
         verify=ssl_verification_enabled,
         headers=_headers,
         allow_redirects=True,
-        data={
-            'AuthMethod': 'DuoAdfsAdapter',
-            'Context': context,
-            'sig_response': signed_response,
-        }
+        data=data
     )
-    logging.debug(u'''Request:
-            * url: {}
-            * headers: {}
-        Response:
-            * status: {}
-            * headers: {}
-            * body: {}
-        '''.format(roles_page_url, response.request.headers, response.status_code, response.headers,
-                   response.text))
+    trace_http_request(roles_page_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
     if response.status_code != 200:
         raise click.ClickException(
@@ -204,24 +201,17 @@ def _authentication_result(
         ssl_verification_enabled
 ):
     status_for_url = "https://{}/frame/status".format(duo_host)
+    data = {
+        'sid': sid,
+        'txid': duo_transaction_id
+    }
     response = session.post(
         status_for_url,
         verify=ssl_verification_enabled,
         headers=_headers,
-        data={
-            'sid': sid,
-            'txid': duo_transaction_id
-        }
+        data=data
     )
-    logging.debug(u'''Request:
-        * url: {}
-        * headers: {}
-    Response:
-        * status: {}
-        * headers: {}
-        * body: {}
-    '''.format(status_for_url, response.request.headers, response.status_code, response.headers,
-               response.text))
+    trace_http_request(status_for_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
     if response.status_code != 200:
         raise click.ClickException(
@@ -260,23 +250,16 @@ def _load_duo_result_url(
         ssl_verification_enabled
 ):
     result_for_url = 'https://{}'.format(duo_host) + result_url
+    data = {
+        'sid': sid
+    }
     response = session.post(
         result_for_url,
         verify=ssl_verification_enabled,
         headers=_headers,
-        data={
-            'sid': sid
-        }
+        data=data
     )
-    logging.debug(u'''Request:
-        * url: {}
-        * headers: {}
-    Response:
-        * status: {}
-        * headers: {}
-        * body: {}
-    '''.format(result_for_url, response.request.headers, response.status_code, response.headers,
-               response.text))
+    trace_http_request(result_for_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
     if response.status_code != 200:
         raise click.ClickException(
@@ -300,24 +283,17 @@ def _verify_authentication_status(duo_host, sid, duo_transaction_id, session,
     responses = []
     while len(responses) < 10:
         status_for_url = "https://{}/frame/status".format(duo_host)
+        data = {
+            'sid': sid,
+            'txid': duo_transaction_id
+        }
         response = session.post(
             status_for_url,
             verify=ssl_verification_enabled,
             headers=_headers,
-            data={
-                'sid': sid,
-                'txid': duo_transaction_id
-            }
+            data=data
         )
-        logging.debug(u'''Request:
-            * url: {}
-            * headers: {}
-        Response:
-            * status: {}
-            * headers: {}
-            * body: {}
-        '''.format(status_for_url, response.request.headers, response.status_code, response.headers,
-                response.text))
+        trace_http_request(status_for_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
         if response.status_code != 200:
             raise click.ClickException(
@@ -334,7 +310,7 @@ def _verify_authentication_status(duo_host, sid, duo_transaction_id, session,
                 )
             )
 
-        if json_response['response']['status_code'] not in ['answered', 'calling', 'pushed', 'u2f_sent']:
+        if json_response['response']['status_code'] not in ['answered', 'calling', 'pushed', 'webauthn_sent']:
             raise click.ClickException(
                 u'There was an issue during second factor verification. The error response: {}'.format(
                     response.text
@@ -344,39 +320,38 @@ def _verify_authentication_status(duo_host, sid, duo_transaction_id, session,
         if json_response['response']['status_code'] in ['pushed', 'answered', 'allow']:
             return duo_transaction_id
 
-        if json_response['response']['status_code'] == 'u2f_sent' and len(json_response['response']['u2f_sign_request']) > 0:
-            u2f_sign_requests = json_response['response']['u2f_sign_request']
+        if json_response['response']['status_code'] == 'webauthn_sent' and len(json_response['response']['webauthn_credential_request_options']) > 0:
+            webauthn_credential_request_options = json_response['response']['webauthn_credential_request_options']
+            webauthn_credential_request_options["challenge"] = base64.b64decode(webauthn_credential_request_options["challenge"])
+            for cred in webauthn_credential_request_options["allowCredentials"]:
+                cred["id"] = base64.urlsafe_b64decode(cred["id"] + "==") # Add arbitrary padding characters, unnecessary ones are ignored
+                cred.pop("transports")
 
-            # appId, challenge and session is the same for all requests, get them from the first
-            u2f_app_id = u2f_sign_requests[0]['appId']
-            u2f_challenge = u2f_sign_requests[0]['challenge']
-            u2f_session_id = u2f_sign_requests[0]['sessionId']
+            webauthn_session_id = webauthn_credential_request_options.pop('sessionId')
 
             devices = list(CtapHidDevice.list_devices())
             if CtapPcscDevice:
                 devices.extend(list(CtapPcscDevice.list_devices()))
 
             if not devices:
-                click.echo("No FIDO U2F authenticator is eligible.")
+                click.echo("No FIDO U2F / FIDO2 authenticator is eligible.")
                 return "cancelled"
 
             threads = []
-            u2f_response = {
-                "sessionId": u2f_session_id
+            webauthn_response = {
+                "sessionId": webauthn_session_id
             }
             rq = queue.Queue()
             cancel = Event()
             for device in devices:
                 t = Thread(
-                    target=_u2f_sign,
+                    target=_webauthn_get_assertion,
                     args=(
                         device,
-                        u2f_app_id,
-                        u2f_challenge,
-                        u2f_sign_requests,
+                        webauthn_credential_request_options,
                         duo_host,
                         sid,
-                        u2f_response,
+                        webauthn_response,
                         session,
                         ssl_verification_enabled,
                         cancel,
@@ -399,27 +374,34 @@ def _verify_authentication_status(duo_host, sid, duo_transaction_id, session,
     )
 
 
-def _u2f_sign(device, u2f_app_id, u2f_challenge, u2f_sign_requests, duo_host, sid, u2f_response, session, ssl_verification_enabled, cancel, rq):
-    click.echo("Activate your FIDO U2F authenticator now: '{}'".format(device), err=True)
-    client = U2fClient(device, u2f_app_id)
+def _webauthn_get_assertion(device, webauthn_credential_request_options, duo_host, sid, webauthn_response, session, ssl_verification_enabled, cancel, rq):
+    click.echo("Activate your FIDO U2F / FIDO2 authenticator now: '{}'".format(device), err=True)
+    client = Fido2Client(device, webauthn_credential_request_options["extensions"]["appid"])
     try:
-        u2f_response.update(
-                client.sign(
-                u2f_app_id,
-                u2f_challenge,
-                u2f_sign_requests,
-                event=cancel
-            )
+        assertion = client.get_assertion(
+                webauthn_credential_request_options,
+                event=cancel,
         )
+        authenticator_assertion_response = assertion.get_response(0)
+        assertion_response = assertion.get_assertions()[0]
 
-        # Cancel the other U2F prompts
-        cancel.set()
+        webauthn_response["id"] = base64.urlsafe_b64encode(assertion_response.credential["id"]).decode('ascii').rstrip("=") # Strip trailing padding characters
+        webauthn_response["rawId"] = webauthn_response["id"]
+        webauthn_response["type"] = assertion_response.credential["type"]
+        webauthn_response["authenticatorData"] = base64.urlsafe_b64encode(assertion_response.auth_data).decode('ascii')
+        webauthn_response["clientDataJSON"] = base64.urlsafe_b64encode(authenticator_assertion_response["clientData"]).decode('ascii')
+        webauthn_response["signature"] = binascii.hexlify(assertion_response.signature).decode("ascii")
+        webauthn_response["extensionResults"] = authenticator_assertion_response["extensionResults"]
+        logging.debug('webauthn_response: {}'.format(webauthn_response))
         
-        click.echo("Got response from FIDO U2F authenticator: '{}'".format(device), err=True)
-        rq.put(_submit_u2f_response(duo_host, sid, u2f_response, session, ssl_verification_enabled))
+        click.echo("Got response from FIDO U2F / FIDO2 authenticator: '{}'".format(device), err=True)
+        rq.put(_submit_webauthn_response(duo_host, sid, webauthn_response, session, ssl_verification_enabled))
     except:
-        pass
+        raise
     finally:
+        # Cancel the other FIDO U2F / FIDO2 prompts
+        cancel.set()
+
         device.close()
 
 
@@ -442,6 +424,14 @@ def _app(request_signature):
 def _initiate_authentication(duo_host, duo_request_signature, roles_page_url, session,
                              ssl_verification_enabled):
     prompt_for_url = 'https://{}/frame/web/v1/auth'.format(duo_host)
+    data = {
+        'parent': roles_page_url,
+        'java_version': '',
+        'flash_version': '',
+        'screen_resolution_width': '1280',
+        'screen_resolution_height': '800',
+        'color_depth': '24',
+    }
     response = session.post(
         prompt_for_url,
         verify=ssl_verification_enabled,
@@ -461,24 +451,9 @@ def _initiate_authentication(duo_host, duo_request_signature, roles_page_url, se
             'parent': roles_page_url,
             'v': '2.3',
         },
-        data={
-            'parent': roles_page_url,
-            'java_version': '',
-            'flash_version': '',
-            'screen_resolution_width': '1280',
-            'screen_resolution_height': '800',
-            'color_depth': '24',
-        }
+        data=data
     )
-    logging.debug(u'''Request:
-        * url: {}
-        * headers: {}
-    Response:
-        * status: {}
-        * headers: {}
-        * body: {}
-    '''.format(prompt_for_url, response.request.headers, response.status_code, response.headers,
-               response.text))
+    trace_http_request(prompt_for_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
     if response.status_code != 200 or response.url is None:
         return (None, None, None, None, None), False
@@ -494,8 +469,8 @@ def _initiate_authentication(duo_host, duo_request_signature, roles_page_url, se
     sid = query['sid']
     preferred_factor = _preferred_factor(html_response)
     preferred_device = _preferred_device(html_response)
-    u2f_supported = _u2f_supported(html_response)
-    return (sid, preferred_factor, preferred_device, u2f_supported, None), True
+    webauthn_supported = _webauthn_supported(html_response)
+    return (sid, preferred_factor, preferred_device, webauthn_supported, None), True
 
 
 def _js_cookie(html_response):
@@ -516,49 +491,32 @@ def _preferred_device(html_response):
     return element is not None and element.get('value') or None
 
 
-def _u2f_supported(html_response):
-    u2f_supported_query = './/input[@name="factor"][@value="U2F Token"]'
-    elements = html_response.findall(u2f_supported_query)
+def _webauthn_supported(html_response):
+    webauthn_supported_query = './/input[@name="factor"][@value="WebAuthn Credential"]'
+    elements = html_response.findall(webauthn_supported_query)
     return len(elements) > 0
 
 
-def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred_device, u2f_supported, session,
+def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred_device, webauthn_supported, session,
                                       ssl_verification_enabled):
     prompt_for_url = "https://{}/frame/prompt".format(duo_host)
-    if u2f_supported:
-        response = session.post(
-            prompt_for_url,
-            verify=ssl_verification_enabled,
-            headers=_headers,
-            data={
-                'sid': sid,
-                'factor': "U2F Token",
-                'device': 'u2f_token',
-                'post_auth_action': ''
-            }
-        )
-    else:
-        click.echo("Triggering authentication method: '{}'".format(preferred_factor), err=True)
-        response = session.post(
-            prompt_for_url,
-            verify=ssl_verification_enabled,
-            headers=_headers,
-            data={
-                'sid': sid,
-                'factor': preferred_factor,
-                'device': preferred_device,
-                'out_of_date': ''
-            }
-        )
-    logging.debug(u'''Request:
-        * url: {}
-        * headers: {}
-    Response:
-        * status: {}
-        * headers: {}
-        * body: {}
-    '''.format(prompt_for_url, response.request.headers, response.status_code, response.headers,
-               response.text))
+    if webauthn_supported and preferred_factor == preferred_device:
+        preferred_factor = 'WebAuthn Credential'
+    click.echo("Triggering authentication method: '{}' with '{}".format(preferred_factor, preferred_device), err=True)
+    data = {
+        'sid': sid,
+        'factor': preferred_factor,
+        'device': preferred_device,
+        'post_auth_action': '',
+        'out_of_date': '',
+    }
+    response = session.post(
+        prompt_for_url,
+        verify=ssl_verification_enabled,
+        headers=_headers,
+        data=data
+    )
+    trace_http_request(prompt_for_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
     if response.status_code != 200:
         raise click.ClickException(
@@ -576,32 +534,25 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
     return json_response['response']['txid']
 
 
-def _submit_u2f_response(duo_host, sid, u2f_response, session, ssl_verification_enabled):
+def _submit_webauthn_response(duo_host, sid, webauthn_response, session, ssl_verification_enabled):
     prompt_for_url = "https://{}/frame/prompt".format(duo_host)
+    data = {
+        'sid': sid,
+        'device': 'webauthn_credential',
+        'factor': "webauthn_finish",
+        'response_data': json.dumps(webauthn_response),
+    }
     response = session.post(
         prompt_for_url,
         verify=ssl_verification_enabled,
         headers=_headers,
-        data={
-            'sid': sid,
-            'device': 'u2f_token',
-            'factor': "u2f_finish",
-            'response_data': json.dumps(u2f_response),
-        }
+        data=data
     )
-    logging.debug(u'''Request:
-        * url: {}
-        * headers: {}
-    Response:
-        * status: {}
-        * headers: {}
-        * body: {}
-    '''.format(prompt_for_url, response.request.headers, response.status_code, response.headers,
-               response.text))
+    trace_http_request(prompt_for_url, response.request.headers, data, response.status_code, response.headers, response.text)
 
     if response.status_code != 200:
         raise click.ClickException(
-            u'Issues during submitting U2F response for the authentication process. The error response {}'.format(
+            u'Issues during submitting WebAuthn response for the authentication process. The error response {}'.format(
                 response
             )
         )

--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -21,7 +21,6 @@ def authenticate(config, username=None, password=None, assertfile=None):
         username=username,
         password=password,
         sspi=config.sspi,
-        webauthn_trigger_default=config.webauthn_trigger_default,
     )
 
     assertion = None
@@ -111,7 +110,7 @@ def _strategy(response, config, session, assertfile=None):
 
     def _duo_extractor():
         def extract():
-            return duo_auth.extract(html_response, config.ssl_verification, config.webauthn_trigger_default, session)
+            return duo_auth.extract(html_response, config.ssl_verification, session)
         return extract
 
     def _symantec_vip_extractor():

--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -21,7 +21,7 @@ def authenticate(config, username=None, password=None, assertfile=None):
         username=username,
         password=password,
         sspi=config.sspi,
-        u2f_trigger_default=config.u2f_trigger_default,
+        webauthn_trigger_default=config.webauthn_trigger_default,
     )
 
     assertion = None
@@ -111,7 +111,7 @@ def _strategy(response, config, session, assertfile=None):
 
     def _duo_extractor():
         def extract():
-            return duo_auth.extract(html_response, config.ssl_verification, config.u2f_trigger_default, session)
+            return duo_auth.extract(html_response, config.ssl_verification, config.webauthn_trigger_default, session)
         return extract
 
     def _symantec_vip_extractor():

--- a/aws_adfs/helpers.py
+++ b/aws_adfs/helpers.py
@@ -1,4 +1,5 @@
 import ctypes
+import logging
 import platform
 import sys
 
@@ -7,3 +8,14 @@ def memset_zero(secret):
         strlen = len(secret)
         offset = sys.getsizeof(secret) - strlen - 1
         ctypes.memset(id(secret) + offset, 0, strlen)
+
+def trace_http_request(url, request_headers, request_data, response_status, response_headers, response_body):
+    logging.debug(u'''Request:
+        * url: {}
+        * headers: {}
+        * data: {}
+    Response:
+        * status: {}
+        * headers: {}
+        * body: {}
+    '''.format(url, request_headers, request_data, response_status, response_headers, response_body))

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -37,7 +37,6 @@ def fetch_html_encoded_roles(
         username=None,
         password=None,
         sspi=None,
-        webauthn_trigger_default=None,
 ):
 
     # Support for Kerberos SSO on Windows via requests_negotiate_sspi

--- a/aws_adfs/html_roles_fetcher.py
+++ b/aws_adfs/html_roles_fetcher.py
@@ -37,7 +37,7 @@ def fetch_html_encoded_roles(
         username=None,
         password=None,
         sspi=None,
-        u2f_trigger_default=None,
+        webauthn_trigger_default=None,
 ):
 
     # Support for Kerberos SSO on Windows via requests_negotiate_sspi

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -129,11 +129,6 @@ from . import authenticator, helpers, prepare, role_chooser
     default=system() == 'Windows',
     help='Whether or not to use Kerberos SSO authentication via SSPI (Windows only, defaults to True).',
 )
-@click.option(
-    '--webauthn-trigger-default/--no-webauthn-trigger-default',
-    default=None,
-    help='Whether or not to also trigger the default authentication method when WebAuthn is available (only works with Duo for now).',
-)
 def login(
     profile,
     region,
@@ -157,7 +152,6 @@ def login(
     no_session_cache,
     assertfile,
     sspi,
-    webauthn_trigger_default,
 ):
     """
     Authenticates an user with active directory credentials
@@ -173,7 +167,6 @@ def login(
         s3_signature_version,
         session_duration,
         sspi,
-        webauthn_trigger_default,
         username_password_command,
     )
 
@@ -399,7 +392,6 @@ def _emit_summary(config, session_duration):
             * S3 Signature Version              : '{}'
             * STS Session Duration in seconds   : '{}'
             * SSPI:                             : '{}'
-            * webauthn and default method            : '{}'
         """.format(
             config.profile,
             config.region,
@@ -412,7 +404,6 @@ def _emit_summary(config, session_duration):
             config.s3_signature_version,
             config.session_duration,
             config.sspi,
-            config.webauthn_trigger_default,
         ),
         err=True
     )
@@ -540,7 +531,6 @@ def _store(config, aws_session_token):
         config_file.set(profile, 'adfs_config.session_duration', config.session_duration)
         config_file.set(profile, 'adfs_config.provider_id', config.provider_id)
         config_file.set(profile, 'adfs_config.sspi', config.sspi)
-        config_file.set(profile, 'adfs_config.webauthn_trigger_default', config.webauthn_trigger_default)
 
     store_config(config.profile, config.aws_credentials_location, credentials_storer)
     if config.profile == 'default':

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -130,9 +130,9 @@ from . import authenticator, helpers, prepare, role_chooser
     help='Whether or not to use Kerberos SSO authentication via SSPI (Windows only, defaults to True).',
 )
 @click.option(
-    '--u2f-trigger-default/--no-u2f-trigger-default',
+    '--webauthn-trigger-default/--no-webauthn-trigger-default',
     default=None,
-    help='Whether or not to also trigger the default authentication method when U2F is available (only works with Duo for now).',
+    help='Whether or not to also trigger the default authentication method when WebAuthn is available (only works with Duo for now).',
 )
 def login(
     profile,
@@ -157,7 +157,7 @@ def login(
     no_session_cache,
     assertfile,
     sspi,
-    u2f_trigger_default,
+    webauthn_trigger_default,
 ):
     """
     Authenticates an user with active directory credentials
@@ -173,7 +173,7 @@ def login(
         s3_signature_version,
         session_duration,
         sspi,
-        u2f_trigger_default,
+        webauthn_trigger_default,
         username_password_command,
     )
 
@@ -399,7 +399,7 @@ def _emit_summary(config, session_duration):
             * S3 Signature Version              : '{}'
             * STS Session Duration in seconds   : '{}'
             * SSPI:                             : '{}'
-            * U2F and default method            : '{}'
+            * webauthn and default method            : '{}'
         """.format(
             config.profile,
             config.region,
@@ -412,7 +412,7 @@ def _emit_summary(config, session_duration):
             config.s3_signature_version,
             config.session_duration,
             config.sspi,
-            config.u2f_trigger_default,
+            config.webauthn_trigger_default,
         ),
         err=True
     )
@@ -540,7 +540,7 @@ def _store(config, aws_session_token):
         config_file.set(profile, 'adfs_config.session_duration', config.session_duration)
         config_file.set(profile, 'adfs_config.provider_id', config.provider_id)
         config_file.set(profile, 'adfs_config.sspi', config.sspi)
-        config_file.set(profile, 'adfs_config.u2f_trigger_default', config.u2f_trigger_default)
+        config_file.set(profile, 'adfs_config.webauthn_trigger_default', config.webauthn_trigger_default)
 
     store_config(config.profile, config.aws_credentials_location, credentials_storer)
     if config.profile == 'default':

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -18,7 +18,6 @@ def get_prepared_config(
         s3_signature_version,
         session_duration,
         sspi,
-        webauthn_trigger_default,
         username_password_command,
 ):
     """
@@ -41,7 +40,6 @@ def get_prepared_config(
     :param s3_signature_version: s3 signature version
     :param session_duration: AWS STS session duration (default 1 hour)
     :param sspi: Whether SSPI is enabled
-    :param webauthn_trigger_default: Whether to also trigger the default authentication method when WebAuthn is available
     :param username_password_command: The command used to retrieve username and password information
     """
     def default_if_none(value, default):
@@ -65,7 +63,6 @@ def get_prepared_config(
     )
     adfs_config.session_duration = default_if_none(session_duration, adfs_config.session_duration)
     adfs_config.sspi = default_if_none(sspi, adfs_config.sspi)
-    adfs_config.webauthn_trigger_default = default_if_none(webauthn_trigger_default, adfs_config.webauthn_trigger_default)
     adfs_config.username_password_command = default_if_none(username_password_command, adfs_config.username_password_command)
 
     return adfs_config
@@ -122,9 +119,6 @@ def create_adfs_default_config(profile):
 
     # Whether SSPI is enabled
     config.sspi = system() == "Windows"
-
-    # Whether to also trigger the default authentication method when WebAuthn is available
-    config.webauthn_trigger_default = True
 
     # The command used to retrieve username and password information
     config.username_password_command = None
@@ -194,9 +188,6 @@ def _load_adfs_config_from_stored_profile(adfs_config, profile):
         adfs_config.sspi = ast.literal_eval(config.get_or(
             profile, 'adfs_config.sspi',
             str(adfs_config.sspi)))
-        adfs_config.webauthn_trigger_default = ast.literal_eval(config.get_or(
-            profile, 'adfs_config.webauthn_trigger_default',
-            str(adfs_config.webauthn_trigger_default)))
         adfs_config.username_password_command = config.get_or(profile, 'adfs_config.username_password_command', adfs_config.username_password_command)
 
     if profile == 'default':

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -18,7 +18,7 @@ def get_prepared_config(
         s3_signature_version,
         session_duration,
         sspi,
-        u2f_trigger_default,
+        webauthn_trigger_default,
         username_password_command,
 ):
     """
@@ -41,7 +41,7 @@ def get_prepared_config(
     :param s3_signature_version: s3 signature version
     :param session_duration: AWS STS session duration (default 1 hour)
     :param sspi: Whether SSPI is enabled
-    :param u2f_trigger_default: Whether to also trigger the default authentication method when U2F is available
+    :param webauthn_trigger_default: Whether to also trigger the default authentication method when WebAuthn is available
     :param username_password_command: The command used to retrieve username and password information
     """
     def default_if_none(value, default):
@@ -65,7 +65,7 @@ def get_prepared_config(
     )
     adfs_config.session_duration = default_if_none(session_duration, adfs_config.session_duration)
     adfs_config.sspi = default_if_none(sspi, adfs_config.sspi)
-    adfs_config.u2f_trigger_default = default_if_none(u2f_trigger_default, adfs_config.u2f_trigger_default)
+    adfs_config.webauthn_trigger_default = default_if_none(webauthn_trigger_default, adfs_config.webauthn_trigger_default)
     adfs_config.username_password_command = default_if_none(username_password_command, adfs_config.username_password_command)
 
     return adfs_config
@@ -123,8 +123,8 @@ def create_adfs_default_config(profile):
     # Whether SSPI is enabled
     config.sspi = system() == "Windows"
 
-    # Whether to also trigger the default authentication method when U2F is available
-    config.u2f_trigger_default = True
+    # Whether to also trigger the default authentication method when WebAuthn is available
+    config.webauthn_trigger_default = True
 
     # The command used to retrieve username and password information
     config.username_password_command = None
@@ -194,9 +194,9 @@ def _load_adfs_config_from_stored_profile(adfs_config, profile):
         adfs_config.sspi = ast.literal_eval(config.get_or(
             profile, 'adfs_config.sspi',
             str(adfs_config.sspi)))
-        adfs_config.u2f_trigger_default = ast.literal_eval(config.get_or(
-            profile, 'adfs_config.u2f_trigger_default',
-            str(adfs_config.u2f_trigger_default)))
+        adfs_config.webauthn_trigger_default = ast.literal_eval(config.get_or(
+            profile, 'adfs_config.webauthn_trigger_default',
+            str(adfs_config.webauthn_trigger_default)))
         adfs_config.username_password_command = config.get_or(profile, 'adfs_config.username_password_command', adfs_config.username_password_command)
 
     if profile == 'default':

--- a/poetry.lock
+++ b/poetry.lock
@@ -73,7 +73,7 @@ pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.10"
+version = "2.0.11"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -159,7 +159,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "fido2"
-version = "0.8.1"
+version = "0.9.3"
 description = "Python based FIDO 2.0 library"
 category = "main"
 optional = false
@@ -168,7 +168,6 @@ python-versions = ">=2.7.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 [package.dependencies]
 cryptography = ">=1.5"
 six = "*"
-uhid-freebsd = {version = ">=1.2.1", markers = "platform_system == \"FreeBSD\""}
 
 [package.extras]
 pcsc = ["pyscard"]
@@ -455,14 +454,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "uhid-freebsd"
-version = "1.2.2"
-description = "Get information on FreeBSD uhid devices."
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "urllib3"
 version = "1.26.8"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -490,7 +481,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "eefbe01ae6176c012e1ba9b159acf18611317cb7fedb7676bca876f371ffb6fa"
+content-hash = "5aba754f8393be9f204521b3cbb930b0d9f79fc8174bf392b3b00adb9c57821e"
 
 [metadata.files]
 atomicwrites = [
@@ -566,8 +557,8 @@ cffi = [
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
-    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+    {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
+    {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -629,7 +620,7 @@ decorator = [
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
 ]
 fido2 = [
-    {file = "fido2-0.8.1.tar.gz", hash = "sha256:449068f6876f397c8bb96ebc6a75c81c2692f045126d3f13ece21d409acdf7c3"},
+    {file = "fido2-0.9.3.tar.gz", hash = "sha256:b45e89a6109cfcb7f1bb513776aa2d6408e95c4822f83a253918b944083466ec"},
 ]
 gssapi = [
     {file = "gssapi-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c02a563d7e8b4005ccfc1f6080eaf0805c052876397ea9fb03b7ee725bbbbccc"},
@@ -827,9 +818,6 @@ toml = [
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
     {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
-]
-uhid-freebsd = [
-    {file = "uhid-freebsd-1.2.2.tar.gz", hash = "sha256:3670374111e9cde795323992809c1299c95c46e96b9bd888c3b340a4e1e733bc"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ python = "^3.6"
 botocore = ">=1.12.6"
 click = "*"
 configparser = "*"
-fido2 = "^0.8.1" # fido2 0.9.0 is a breaking release
+fido2 = ">=0.9.3"
 lxml = "*"
 requests = "*"
 requests-kerberos = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.0.0-alpha.7"
+version = "2.0.0-alpha.8"
 description = "AWS Cli authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.0.0-alpha.9"
+version = "2.0.0-alpha.11"
 description = "AWS Cli authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.0.0-alpha.8"
+version = "2.0.0-alpha.9"
 description = "AWS Cli authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.0.0-alpha.2"
+version = "2.0.0-alpha.7"
 description = "AWS Cli authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -298,7 +298,7 @@ class TestAuthenticator:
         self.irrelevant_config.adfs_ca_bundle = None
         self.irrelevant_config.provider_id = 'irrelevant provider identifier'
         self.irrelevant_config.sspi = True
-        self.irrelevant_config.u2f_trigger_default = True
+        self.irrelevant_config.webauthn_trigger_default = True
 
         self.http_session = type('', (), {})()
         self.http_session.post = lambda *args, **kwargs: None

--- a/test/test_authenticator.py
+++ b/test/test_authenticator.py
@@ -298,7 +298,6 @@ class TestAuthenticator:
         self.irrelevant_config.adfs_ca_bundle = None
         self.irrelevant_config.provider_id = 'irrelevant provider identifier'
         self.irrelevant_config.sspi = True
-        self.irrelevant_config.webauthn_trigger_default = True
 
         self.http_session = type('', (), {})()
         self.http_session.post = lambda *args, **kwargs: None

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -23,7 +23,6 @@ class TestConfigPreparation:
         default_s3_signature_version = None
         default_session_duration = 3600
         default_sspi = False
-        default_webauthn_trigger_default = False
         default_username_password_command = None
 
         # when configuration is prepared for not existing profile
@@ -38,7 +37,6 @@ class TestConfigPreparation:
             default_s3_signature_version,
             default_session_duration,
             default_sspi,
-            default_webauthn_trigger_default,
             default_username_password_command,
         )
 
@@ -50,7 +48,6 @@ class TestConfigPreparation:
         assert default_output_format == adfs_config.output_format
         assert default_session_duration == adfs_config.session_duration
         assert default_sspi == adfs_config.sspi
-        assert default_webauthn_trigger_default == adfs_config.webauthn_trigger_default
         assert default_username_password_command == adfs_config.username_password_command
 
     def test_when_the_profile_exists_but_lacks_ssl_verification_use_default_value(self):
@@ -68,7 +65,6 @@ class TestConfigPreparation:
         default_ssl_config = True
         default_adfs_ca_bundle = None
         default_sspi = True
-        default_webauthn_trigger_default = True
         irrelevant_region = 'irrelevant_region'
         irrelevant_adfs_host = 'irrelevant_adfs_host'
         irrelevant_output_format = 'irrelevant_output_format'
@@ -89,7 +85,6 @@ class TestConfigPreparation:
             irrelevant_s3_signature_version,
             irrelevant_session_duration,
             default_sspi,
-            default_webauthn_trigger_default,
             irrelevant_username_password_command,
         )
 
@@ -97,4 +92,3 @@ class TestConfigPreparation:
         assert default_ssl_config == adfs_config.ssl_verification
         assert default_adfs_ca_bundle == adfs_config.adfs_ca_bundle
         assert default_sspi == adfs_config.sspi
-        assert default_webauthn_trigger_default == adfs_config.webauthn_trigger_default

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -23,7 +23,7 @@ class TestConfigPreparation:
         default_s3_signature_version = None
         default_session_duration = 3600
         default_sspi = False
-        default_u2f_trigger_default = False
+        default_webauthn_trigger_default = False
         default_username_password_command = None
 
         # when configuration is prepared for not existing profile
@@ -38,7 +38,7 @@ class TestConfigPreparation:
             default_s3_signature_version,
             default_session_duration,
             default_sspi,
-            default_u2f_trigger_default,
+            default_webauthn_trigger_default,
             default_username_password_command,
         )
 
@@ -50,7 +50,7 @@ class TestConfigPreparation:
         assert default_output_format == adfs_config.output_format
         assert default_session_duration == adfs_config.session_duration
         assert default_sspi == adfs_config.sspi
-        assert default_u2f_trigger_default == adfs_config.u2f_trigger_default
+        assert default_webauthn_trigger_default == adfs_config.webauthn_trigger_default
         assert default_username_password_command == adfs_config.username_password_command
 
     def test_when_the_profile_exists_but_lacks_ssl_verification_use_default_value(self):
@@ -68,7 +68,7 @@ class TestConfigPreparation:
         default_ssl_config = True
         default_adfs_ca_bundle = None
         default_sspi = True
-        default_u2f_trigger_default = True
+        default_webauthn_trigger_default = True
         irrelevant_region = 'irrelevant_region'
         irrelevant_adfs_host = 'irrelevant_adfs_host'
         irrelevant_output_format = 'irrelevant_output_format'
@@ -89,7 +89,7 @@ class TestConfigPreparation:
             irrelevant_s3_signature_version,
             irrelevant_session_duration,
             default_sspi,
-            default_u2f_trigger_default,
+            default_webauthn_trigger_default,
             irrelevant_username_password_command,
         )
 
@@ -97,4 +97,4 @@ class TestConfigPreparation:
         assert default_ssl_config == adfs_config.ssl_verification
         assert default_adfs_ca_bundle == adfs_config.adfs_ca_bundle
         assert default_sspi == adfs_config.sspi
-        assert default_u2f_trigger_default == adfs_config.u2f_trigger_default
+        assert default_webauthn_trigger_default == adfs_config.webauthn_trigger_default


### PR DESCRIPTION
Resolves #208 

- Switch from Duo U2F to WebAuthn
- Introduce trace_http_request helper function

Reference documentation used to implement this:
- https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#authenticatorGetAssertion
- https://w3c.github.io/webauthn/#sctn-usecase-authentication