### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ aws-adfs integrates with:
 
 # Installation
 
+* prerequisites
+    ```
+    python-gssapi
+    ```    
+
 * user local installation with [pipx](https://github.com/pypa/pipx)
 
     ```


### PR DESCRIPTION
Prerequirements for install aws-adfs on linux using pip. Without python-gssapi cause problems with pip install aws-adfs command.