### PR TITLE
Hide RSA token

### DIFF
--- a/aws_adfs/_rsa_authenticator.py
+++ b/aws_adfs/_rsa_authenticator.py
@@ -22,7 +22,7 @@ def extract(html_response, ssl_verification_enabled, session):
 
     roles_page_url = _action_url_on_validation_success(html_response)
 
-    rsa_securid_code = click.prompt(text='Enter your RSA SecurID token', type=str)
+    rsa_securid_code = click.prompt(text='Enter your RSA SecurID token', type=str, hide_input=True)
 
     click.echo('Going for aws roles', err=True)
     return _retrieve_roles_page(


### PR DESCRIPTION
The RSA token might be composed of the combination of a rotating 6-digits code generated by a device, and a user-chosen PIN. The PIN is considered as secret. The rotating code can be reused for 30s/1min so it shouldn't be displayed either. Overall this field should be hidden.