### PR TITLE
Disable cache if `role_arn` is not provided

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -175,7 +175,7 @@ def login(
     # Get session credentials from cache if not expired to avoid invoking the ADFS host uselessly
     session_cache_dir = (
         None
-        if no_session_cache
+        if no_session_cache or role_arn is None
         else os.path.join(
             os.path.dirname(config.aws_credentials_location), "adfs_cache"
         )


### PR DESCRIPTION
Fix #227 