### PR TITLE
Pin fido2 to below 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.2.2"
+version = "2.2.1"
 description = "AWS CLI authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.2.1"
+version = "2.2.2"
 description = "AWS CLI authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ boto3 = "^1.20.50"
 botocore = ">=1.12.6"
 click = "*"
 configparser = "*"
-fido2 = ">=0.9.3"
+fido2 = ">=0.9.3, <1.0.0"
 lxml = "*"
 requests = "*"
 requests-kerberos = [


### PR DESCRIPTION
Quick workaround for aws-adfs #243

I'm not at all sure this is sufficient, just wanted to provide a starting point.