### PR TITLE
Tolerate missing 'transports' key from WebAuthn challenge, and fix regression with CTAP1 device since fido2 1.0.0

### DIFF
--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -3,7 +3,7 @@ import binascii
 import click
 import lxml.etree as ET
 
-from fido2.client import CollectedClientData, ClientError, Fido2Client
+from fido2.client import ClientError, Fido2Client
 from fido2.hid import CtapHidDevice
 try:
     from fido2.pcsc import CtapPcscDevice

--- a/aws_adfs/_duo_authenticator.py
+++ b/aws_adfs/_duo_authenticator.py
@@ -74,7 +74,7 @@ def extract(html_response, ssl_verification_enabled, session):
             if auth_signature == "cancelled":
                 click.echo("Authentication method cancelled, aborting.")
                 exit(-2)
-                    
+
         click.echo('Going for aws roles', err=True)
         return _retrieve_roles_page(
             roles_page_url,
@@ -356,7 +356,7 @@ def _webauthn_get_assertion(device, webauthn_credential_request_options, duo_hos
         webauthn_response["signature"] = binascii.hexlify(assertion_response.signature).decode("ascii")
         webauthn_response["extensionResults"] = authenticator_assertion_response["extensionResults"]
         logging.debug('webauthn_response: {}'.format(webauthn_response))
-        
+
         click.echo("Got response from FIDO U2F / FIDO2 authenticator: '{}'".format(device), err=True)
         rq.put(_submit_webauthn_response(duo_host, sid, webauthn_response, session, ssl_verification_enabled))
     except Exception as e:
@@ -467,7 +467,7 @@ def _begin_authentication_transaction(duo_host, sid, preferred_factor, preferred
     prompt_for_url = "https://{}/frame/prompt".format(duo_host)
     if webauthn_supported and preferred_factor == preferred_device:
         preferred_factor = 'WebAuthn Credential'
-    click.echo("Triggering authentication method: '{}' with '{}".format(preferred_factor, preferred_device), err=True)
+    click.echo("Triggering authentication method: '{}' with '{}'".format(preferred_factor, preferred_device), err=True)
     data = {
         'sid': sid,
         'factor': preferred_factor,

--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -507,7 +507,7 @@ def _begin_authentication_transaction(
     duo_url = duo_host + "/frame/v4/prompt"
 
     click.echo(
-        "Triggering authentication method: '{}' with '{}".format(preferred_factor, preferred_device),
+        "Triggering authentication method: '{}' with '{}'".format(preferred_factor, preferred_device),
         err=True,
     )
 

--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -2,7 +2,7 @@ import binascii
 import click
 import lxml.etree as ET
 
-from fido2.client import CollectedClientData, ClientError, Fido2Client
+from fido2.client import ClientError, Fido2Client
 from fido2.hid import CtapHidDevice
 from fido2.utils import websafe_decode, websafe_encode
 

--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -279,7 +279,7 @@ def _verify_authentication_status(duo_host, sid, txid, session, ssl_verification
                 cred["id"] = base64.urlsafe_b64decode(
                     cred["id"] + "=="
                 )  # Add arbitrary padding characters, unnecessary ones are ignored
-                cred.pop("transports")
+                cred.pop("transports", None)
 
             webauthn_session_id = webauthn_credential_request_options.pop("sessionId")
 

--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -350,7 +350,9 @@ def _webauthn_get_assertion(
         webauthn_response["authenticatorData"] = websafe_encode(assertion_response.auth_data)
         webauthn_response["clientDataJSON"] = websafe_encode(authenticator_assertion_response["clientData"])
         webauthn_response["signature"] = binascii.hexlify(assertion_response.signature).decode("ascii")
-        webauthn_response["extensionResults"] = authenticator_assertion_response["extensionResults"]
+        extension_results = authenticator_assertion_response["extensionResults"]
+        if extension_results:
+            webauthn_response["extensionResults"] = extension_results
         logging.debug("webauthn_response: {}".format(webauthn_response))
 
         click.echo(

--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -1,10 +1,10 @@
-import base64
 import binascii
 import click
 import lxml.etree as ET
 
 from fido2.client import CollectedClientData, ClientError, Fido2Client
 from fido2.hid import CtapHidDevice
+from fido2.utils import websafe_decode, websafe_encode
 
 try:
     from fido2.pcsc import CtapPcscDevice
@@ -274,11 +274,9 @@ def _verify_authentication_status(duo_host, sid, txid, session, ssl_verification
             and len(json_response["response"]["webauthn_credential_request_options"]) > 0
         ):
             webauthn_credential_request_options = json_response["response"]["webauthn_credential_request_options"]
-            webauthn_credential_request_options["challenge"] = base64.b64decode(webauthn_credential_request_options["challenge"])
+            webauthn_credential_request_options["challenge"] = websafe_decode(webauthn_credential_request_options["challenge"])
             for cred in webauthn_credential_request_options["allowCredentials"]:
-                cred["id"] = base64.urlsafe_b64decode(
-                    cred["id"] + "=="
-                )  # Add arbitrary padding characters, unnecessary ones are ignored
+                cred["id"] = websafe_decode(cred["id"])
                 cred.pop("transports", None)
 
             webauthn_session_id = webauthn_credential_request_options.pop("sessionId")
@@ -346,15 +344,11 @@ def _webauthn_get_assertion(
         authenticator_assertion_response = assertion.get_response(0)
         assertion_response = assertion.get_assertions()[0]
 
-        webauthn_response["id"] = (
-            base64.urlsafe_b64encode(assertion_response.credential["id"]).decode("ascii").rstrip("=")
-        )  # Strip trailing padding characters
+        webauthn_response["id"] = websafe_encode(assertion_response.credential["id"])
         webauthn_response["rawId"] = webauthn_response["id"]
         webauthn_response["type"] = assertion_response.credential["type"]
-        webauthn_response["authenticatorData"] = base64.urlsafe_b64encode(assertion_response.auth_data).decode("ascii")
-        webauthn_response["clientDataJSON"] = base64.urlsafe_b64encode(authenticator_assertion_response["clientData"]).decode(
-            "ascii"
-        )
+        webauthn_response["authenticatorData"] = websafe_encode(assertion_response.auth_data)
+        webauthn_response["clientDataJSON"] = websafe_encode(authenticator_assertion_response["clientData"])
         webauthn_response["signature"] = binascii.hexlify(assertion_response.signature).decode("ascii")
         webauthn_response["extensionResults"] = authenticator_assertion_response["extensionResults"]
         logging.debug("webauthn_response: {}".format(webauthn_response))


### PR DESCRIPTION
This PR fixes an issue when the 'transports' field is missing from the WebAuthn challenge.

It also fixes a regression with CTAP1 devices (e.g. Yubikey NEO) which have no `extensionResults` in assertion response since fido2 v1.0.0.
