### PR TITLE
feature: Allow enforcement role_arn config variable

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -139,6 +139,13 @@ from .consts import (
     "--duo-device",
     help=f'Use a specific Duo device, overriding the default one configured server side. Depends heavily on the Duo factor used. Known Duo devices that can be used with aws-adfs are "phone1" for "{DUO_UNIVERSAL_PROMPT_FACTOR_DUO_PUSH}" and "{DUO_UNIVERSAL_PROMPT_FACTOR_PHONE_CALL}" factors. For "{DUO_UNIVERSAL_PROMPT_FACTOR_WEBAUTHN}" factor, it is always "None". Only supported with Duo Universal Prompt.',
 )
+@click.option(
+    "--enforce-role-arn",
+    help=f'Only allow the role passed in by --role-arn.',
+    type=bool,
+    is_flag=True,
+    default=False,
+)
 def login(
     profile,
     region,
@@ -164,6 +171,7 @@ def login(
     sspi,
     duo_factor,
     duo_device,
+    enforce_role_arn,
 ):
     """
     Authenticates an user with active directory credentials
@@ -182,6 +190,7 @@ def login(
         username_password_command,
         duo_factor,
         duo_device,
+        enforce_role_arn,
     )
 
     _verification_checks(config)

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -21,6 +21,7 @@ def get_prepared_config(
     username_password_command,
     duo_factor,
     duo_device,
+    enforce_role_arn=False
 ):
     """
     Prepares ADFS configuration for login task.
@@ -45,6 +46,7 @@ def get_prepared_config(
     :param username_password_command: The command used to retrieve username and password information
     :param duo_factor: The specific Duo factor to use
     :param duo_device: The specific Duo device to use
+    :param enforce_role_arn: If role_arn is in config then only allow the provided value
     """
     def default_if_none(value, default):
         return value if value is not None else default
@@ -70,6 +72,7 @@ def get_prepared_config(
     adfs_config.username_password_command = default_if_none(username_password_command, adfs_config.username_password_command)
     adfs_config.duo_factor = default_if_none(duo_factor, adfs_config.duo_factor)
     adfs_config.duo_device = default_if_none(duo_device, adfs_config.duo_device)
+    adfs_config.enforce_role_arn = enforce_role_arn
 
     return adfs_config
 

--- a/aws_adfs/role_chooser.py
+++ b/aws_adfs/role_chooser.py
@@ -1,6 +1,5 @@
 import collections
 import logging
-import sys
 import click
 
 
@@ -32,7 +31,8 @@ def choose_role_to_assume(config, principal_roles):
         return chosen_principal_arn, chosen_role_arn
     else:
         if config.enforce_role_arn:
-            sys.exit(-3)
+            click.echo('Not allowed to assume role {} and role_arn is enforced'.format(config.role_arn), err=True)
+            exit(-3)
 
     if len(role_collection) == 1:
         logging.debug(u'There is only one role to choose')

--- a/aws_adfs/role_chooser.py
+++ b/aws_adfs/role_chooser.py
@@ -1,6 +1,6 @@
 import collections
 import logging
-
+import sys
 import click
 
 
@@ -30,6 +30,9 @@ def choose_role_to_assume(config, principal_roles):
         chosen_principal_arn = chosen_principal_role[0][0]
         chosen_role_arn = chosen_principal_role[0][1]
         return chosen_principal_arn, chosen_role_arn
+    else:
+        if config.enforce_role_arn:
+            sys.exit(-3)
 
     if len(role_collection) == 1:
         logging.debug(u'There is only one role to choose')

--- a/test/test_config_preparation.py
+++ b/test/test_config_preparation.py
@@ -26,6 +26,7 @@ class TestConfigPreparation:
         default_username_password_command = None
         default_duo_factor = None
         default_duo_device = None
+        default_enforce_role_arn = False
 
         # when configuration is prepared for not existing profile
         adfs_config = prepare.get_prepared_config(
@@ -55,6 +56,7 @@ class TestConfigPreparation:
         assert default_username_password_command == adfs_config.username_password_command
         assert default_duo_factor == adfs_config.duo_factor
         assert default_duo_device == adfs_config.duo_device
+        assert default_enforce_role_arn == adfs_config.enforce_role_arn
 
     def test_when_the_profile_exists_but_lacks_ssl_verification_use_default_value(self):
         # given profile to read the configuration exists

--- a/test/test_role_chooser.py
+++ b/test/test_role_chooser.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from aws_adfs import role_chooser
 from aws_adfs.role_chooser import click
 
@@ -23,7 +24,7 @@ class TestRoleChooser:
         # given role already chosen by an user
         already_chosen_role_arn = 'already_chosen_role_arn'
 
-        config_with_already_chosen_role = type('', (), {})()
+        config_with_already_chosen_role = deepcopy(self.irrelevant_config)
         config_with_already_chosen_role.role_arn = already_chosen_role_arn
 
         # and roles collection for the user still contains already chosen role
@@ -107,7 +108,7 @@ class TestRoleChooser:
         }
 
         # and there wasn't any previously used role
-        config_without_previously_used_role = type('', (), {})()
+        config_without_previously_used_role = deepcopy(self.irrelevant_config)
         config_without_previously_used_role.role_arn = None
 
         # and the user chosen second role
@@ -126,7 +127,7 @@ class TestRoleChooser:
         # given role already chosen by an user
         already_chosen_role_arn = 'already_chosen_role_arn'
 
-        config_with_already_chosen_role = type('', (), {})()
+        config_with_already_chosen_role = deepcopy(self.irrelevant_config)
         config_with_already_chosen_role.role_arn = already_chosen_role_arn
 
         # and roles collection for the user contains two roles without already chosen by the user
@@ -157,7 +158,7 @@ class TestRoleChooser:
 
     def test_asks_user_to_choose_a_role(self):
         # given the role is assumed for the first time
-        config = type('', (), {})()
+        config = deepcopy(self.irrelevant_config)
         config.role_arn = None
 
         # and the user chosen second role


### PR DESCRIPTION
See issue [342](https://github.com/venth/aws-adfs/issues/342)

Allow enforcing of the provided role_arn. In order to be backwards compatible default to False. So this behavior is opt-in.