### PR TITLE
Add support for Duo Verified Push MFA

### DIFF
--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -288,6 +288,14 @@ def _verify_authentication_status(duo_host, sid, txid, session, ssl_verification
                 "There was an issue during second factor verification. The error response: {}".format(response.text)
             )
 
+        if json_response["response"]["status_code"] == "pushed":
+            verification_code = json_response["response"].get("risk_based_factor_selection_data", {}).get("step_up_code")
+            if verification_code:
+                click.echo(
+                    f"Duo Verified Push MFA code: {verification_code}",
+                    err=True,
+                )
+
         if json_response["response"]["status_code"] in ["pushed", "answered", "allow"]:
             return txid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool]
 [tool.poetry]
 name = "aws-adfs"
-version = "2.4.0"
+version = "2.5.0a0"
 description = "AWS CLI authenticator via ADFS - small command-line tool to authenticate via ADFS and assume chosen role"
 keywords = ["aws", "adfs", "console", "tool"]
 classifiers = [


### PR DESCRIPTION
When [Duo Verified Push MFA](https://duo.com/blog/verified-duo-push-makes-mfa-more-secure) is enabled, a verification code is requested to be entered in the Duo mobile application.

With this change, the verification code is displayed in aws-adfs normal output (on stderr), e.g.:

```
# rm ~/.aws/adfs_cookies_*

# aws-adfs login --duo-factor "Duo Push" --duo-device "phone1" [...]
[...]
Sending request for authentication
Waiting for additional authentication
Triggering authentication method: 'Duo Push' with 'phone1'
Duo Verified Push MFA code: 123456
[...]
```

PS: users of other Duo authentication methods like Phone Call or WebAuthn are not concerned by this change.