### PR TITLE
Do not error if release already exists in test.pypi.org

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
           POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.test_pypi_password }}
         run: |
           poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry publish --repository testpypi
+          poetry publish --skip-existing --repository testpypi
 
       - name: Check Version
         id: check-version


### PR DESCRIPTION
PyPI.org was in maintenance when 2.6.1 was released, so publishing to it failed:
```
Publishing aws-adfs (2.6.1) to PyPI
 - Uploading aws-adfs-2.6.1.tar.gz 0%
 - Uploading aws-adfs-2.6.1.tar.gz 100%


  UploadError

  HTTP Error 403: Read-only mode: Uploads are temporarily disabled.

  at /opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/poetry/publishing/uploader.py:216 in _upload
      212│                     self._register(session, url)
      213│                 except HTTPError as e:
      214│                     raise UploadError(e)
      215│ 
    → 216│             raise UploadError(e)
      217│ 
      2[18](https://github.com/venth/aws-adfs/actions/runs/3345574657/jobs/5541375181#step:9:19)│     def _do_upload(
      2[19](https://github.com/venth/aws-adfs/actions/runs/3345574657/jobs/5541375181#step:9:20)│         self, session, url, dry_run=False
      220│     ):  # type: (requests.Session, str, Optional[bool]) -> None
 - Uploading aws-adfs-2.6.1.tar.gz 100%
Error: Process completed with exit code 1.
```
https://github.com/venth/aws-adfs/actions/runs/3345574657/jobs/5541375181

But publishing to test.pypi.org right before worked fine.

New attempts to run the failed Github Actions job then failed because the release was existing at https://test.pypi.org/project/aws-adfs/2.6.1/ :
```
Publishing aws-adfs (2.6.1) to testpypi
 - Uploading aws-adfs-2.6.1.tar.gz 0%
 - Uploading aws-adfs-2.6.1.tar.gz 100%


  UploadError

  HTTP Error [40](https://github.com/venth/aws-adfs/actions/runs/3345574657/jobs/5541838723#step:6:41)0: File already exists. See https://test.pypi.org/help/#file-name-reuse for more information.

  at /opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/site-packages/poetry/publishing/uploader.py:216 in _upload
      212│                     self._register(session, url)
      213│                 except HTTPError as e:
      214│                     raise UploadError(e)
      215│ 
    → 216│             raise UploadError(e)
      217│ 
      218│     def _do_upload(
      219│         self, session, url, dry_run=False
      220│     ):  # type: (requests.Session, str, Optional[bool]) -> None
 - Uploading aws-adfs-2.6.1.tar.gz 100%
Error: Process completed with exit code 1.
```

https://github.com/venth/aws-adfs/actions/runs/3345574657/jobs/5544492365

This PR allows to skip publishing to test.pypi.org is the release is already existing there, thus allowing to retry publishing to pypi.org.