### PR TITLE
Add support for verification codes on Azure Cloud MFA

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ aws-adfs integrates with:
   * FIDO U2F (CTAP1) / FIDO2 (CTAP2) hardware authenticators using the `WebAuthn Security Key` authentication method.
 * [Symantec VIP](https://vip.symantec.com/) MFA provider
 * [RSA SecurID](https://www.rsa.com/) MFA provider
+* [Azure AD MFA](https://learn.microsoft.com/en-us/azure/active-directory/authentication/concept-mfa-howitworks) with support for:
+  * Microsoft Authenticator app
+  * OTP 6 digit codes
+  * SMS codes
+  * Phone call
 
 ## Setup Dependencies
 
@@ -292,6 +297,8 @@ aws-adfs integrates with:
                                       factors. For "Passcode" and "WebAuthn
                                       Security Key" factors, it is always "None".
       --enforce-role-arn              Only allow the role passed in by --role-arn.
+      --verification-code TEXT        Verification code for multi-factor
+                                      authentication.
       --help                          Show this message and exit.
     ```
     <!-- AWS_LOGIN_HELP_END -->

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ aws-adfs integrates with:
                                       factors. For "Passcode" and "WebAuthn
                                       Security Key" factors, it is always "None".
       --enforce-role-arn              Only allow the role passed in by --role-arn.
-      --aad-verification-code TEXT        Verification code for Azure AD multi-factor authentication
+      --aad-verification-code TEXT    Verification code for Azure AD multi-factor
                                       authentication.
       --help                          Show this message and exit.
     ```

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ aws-adfs integrates with:
                                       factors. For "Passcode" and "WebAuthn
                                       Security Key" factors, it is always "None".
       --enforce-role-arn              Only allow the role passed in by --role-arn.
-      --verification-code TEXT        Verification code for multi-factor
+      --aad-verification-code TEXT        Verification code for Azure AD multi-factor authentication
                                       authentication.
       --help                          Show this message and exit.
     ```

--- a/aws_adfs/_azure_cloud_mfa_authenticator.py
+++ b/aws_adfs/_azure_cloud_mfa_authenticator.py
@@ -22,7 +22,7 @@ def extract(html_response, ssl_verification_enabled, verification_code, session)
     """
 
     click.echo(_mfa_instructions(html_response), err=True)
-    
+
     return _retrieve_roles_page(
         html_response,
         session,
@@ -39,9 +39,10 @@ def _retrieve_roles_page(html_response, session, ssl_verification_enabled, verif
         time.sleep(seconds_to_wait)
 
         verification_code_text = _verification_code_text(html_response)
-        if verification_code_text is not None and verification_code is None:
-            verification_code = click.prompt(verification_code_text)
+        if verification_code_text is not None:
             seconds_to_wait = 0
+            if verification_code is None:
+                verification_code = click.prompt(verification_code_text)
 
         response = session.post(
             _action_url_on_validation_success(html_response),

--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -13,7 +13,7 @@ from . import roles_assertion_extractor
 from .helpers import trace_http_request
 
 
-def authenticate(config, username=None, password=None, assertfile=None):
+def authenticate(config, username=None, password=None, assertfile=None, verification_code=None):
     response, session = html_roles_fetcher.fetch_html_encoded_roles(
         adfs_host=config.adfs_host,
         adfs_cookie_location=config.adfs_cookie_location,
@@ -120,7 +120,7 @@ def _strategy(response, config, session, assertfile=None):
 
     def _azure_cloud_mfa_extractor():
         def extract():
-            return azure_cloud_mfa_auth.extract(html_response, config.ssl_verification, session)
+            return azure_cloud_mfa_auth.extract(html_response, config.ssl_verification, config.verification_code, session)
         return extract
 
     if assertfile is None:

--- a/aws_adfs/authenticator.py
+++ b/aws_adfs/authenticator.py
@@ -13,7 +13,7 @@ from . import roles_assertion_extractor
 from .helpers import trace_http_request
 
 
-def authenticate(config, username=None, password=None, assertfile=None, verification_code=None):
+def authenticate(config, username=None, password=None, assertfile=None, aad_verification_code=None):
     response, session = html_roles_fetcher.fetch_html_encoded_roles(
         adfs_host=config.adfs_host,
         adfs_cookie_location=config.adfs_cookie_location,
@@ -120,7 +120,7 @@ def _strategy(response, config, session, assertfile=None):
 
     def _azure_cloud_mfa_extractor():
         def extract():
-            return azure_cloud_mfa_auth.extract(html_response, config.ssl_verification, config.verification_code, session)
+            return azure_cloud_mfa_auth.extract(html_response, config.ssl_verification, config.aad_verification_code, session)
         return extract
 
     if assertfile is None:

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -149,7 +149,7 @@ from .consts import (
 )
 @click.option(
     "--aad-verification-code",
-    help="Verification code for multi-factor authentication.",
+    help="Verification code for Azure AD multi-factor authentication.",
 )
 def login(
     profile,

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -148,7 +148,7 @@ from .consts import (
     default=False,
 )
 @click.option(
-    "--verification-code",
+    "--aad-verification-code",
     help="Verification code for multi-factor authentication.",
 )
 def login(
@@ -176,7 +176,7 @@ def login(
     sspi,
     duo_factor,
     duo_device,
-    verification_code,
+    aad_verification_code,
     enforce_role_arn,
 ):
     """
@@ -196,7 +196,7 @@ def login(
         username_password_command,
         duo_factor,
         duo_device,
-        verification_code,
+        aad_verification_code,
         enforce_role_arn,
     )
 

--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -147,6 +147,10 @@ from .consts import (
     is_flag=True,
     default=False,
 )
+@click.option(
+    "--verification-code",
+    help="Verification code for multi-factor authentication.",
+)
 def login(
     profile,
     region,
@@ -172,6 +176,7 @@ def login(
     sspi,
     duo_factor,
     duo_device,
+    verification_code,
     enforce_role_arn,
 ):
     """
@@ -191,6 +196,7 @@ def login(
         username_password_command,
         duo_factor,
         duo_device,
+        verification_code,
         enforce_role_arn,
     )
 

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -23,7 +23,8 @@ def get_prepared_config(
     username_password_command,
     duo_factor,
     duo_device,
-    enforce_role_arn=False
+    verification_code,
+    enforce_role_arn=False,
 ):
     """
     Prepares ADFS configuration for login task.
@@ -48,6 +49,7 @@ def get_prepared_config(
     :param username_password_command: The command used to retrieve username and password information
     :param duo_factor: The specific Duo factor to use
     :param duo_device: The specific Duo device to use
+    :param verification_code: If verification code is in config use that for multi-factor authentication
     :param enforce_role_arn: If role_arn is in config then only allow the provided value
     """
     def default_if_none(value, default):
@@ -86,6 +88,7 @@ def get_prepared_config(
     adfs_config.username_password_command = default_if_none(username_password_command, adfs_config.username_password_command)
     adfs_config.duo_factor = default_if_none(duo_factor, adfs_config.duo_factor)
     adfs_config.duo_device = default_if_none(duo_device, adfs_config.duo_device)
+    adfs_config.verification_code = verification_code
     adfs_config.enforce_role_arn = enforce_role_arn
 
     return adfs_config
@@ -149,6 +152,9 @@ def create_adfs_default_config(profile):
     # The specific Duo factor and device to use
     config.duo_factor = None
     config.duo_device = None
+
+    # Verification code
+    config.verification_code = None
 
     return config
 

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -23,7 +23,7 @@ def get_prepared_config(
     username_password_command,
     duo_factor,
     duo_device,
-    verification_code=None,
+    aad_verification_code=None,
     enforce_role_arn=False
 ):
     """
@@ -49,7 +49,7 @@ def get_prepared_config(
     :param username_password_command: The command used to retrieve username and password information
     :param duo_factor: The specific Duo factor to use
     :param duo_device: The specific Duo device to use
-    :param verification_code: If verification code is in config use that for multi-factor authentication
+    :param aad_verification_code: If verification code is in config use that for multi-factor authentication
     :param enforce_role_arn: If role_arn is in config then only allow the provided value
     """
     def default_if_none(value, default):
@@ -88,7 +88,7 @@ def get_prepared_config(
     adfs_config.username_password_command = default_if_none(username_password_command, adfs_config.username_password_command)
     adfs_config.duo_factor = default_if_none(duo_factor, adfs_config.duo_factor)
     adfs_config.duo_device = default_if_none(duo_device, adfs_config.duo_device)
-    adfs_config.verification_code = verification_code
+    adfs_config.aad_verification_code = aad_verification_code
     adfs_config.enforce_role_arn = enforce_role_arn
 
     return adfs_config

--- a/aws_adfs/prepare.py
+++ b/aws_adfs/prepare.py
@@ -23,8 +23,8 @@ def get_prepared_config(
     username_password_command,
     duo_factor,
     duo_device,
-    verification_code,
-    enforce_role_arn=False,
+    verification_code=None,
+    enforce_role_arn=False
 ):
     """
     Prepares ADFS configuration for login task.
@@ -152,9 +152,6 @@ def create_adfs_default_config(profile):
     # The specific Duo factor and device to use
     config.duo_factor = None
     config.duo_device = None
-
-    # Verification code
-    config.verification_code = None
 
     return config
 


### PR DESCRIPTION
This PR aims to allow multiple forms of MFA on Azura Cloud.
Currently, the solution polls the page and cheks for a SAML token, which will be provided if authentication happened externally, e.g. via Microsoft Authenticator app or via a phone call.
But other options for authentication is currently missing.
Verification codes can also be supplied to the page request, for authentication. For example OTP 6-digit codes or SMS codes.
With this PR, I have implemented support for both methods.

The solution will now read the MFA intruction string and print it. It will check if there is an input field for a verification code and prompt the user for it.
If it is not found, it will still poll as the current solution will.
If the verification code is given, the solution only needs to make a request with that, and then the next request should contain the SAML token.

Furthermore, I made it possible to provide the verification code in the command line. If the code is given here, and the solution finds an input field for verification codes, it will use this one, instead of prompting the user for it.
