### PR TITLE
Add support for number matching in Microsoft Authenticator app

### DIFF
--- a/aws_adfs/_azure_cloud_mfa_authenticator.py
+++ b/aws_adfs/_azure_cloud_mfa_authenticator.py
@@ -34,9 +34,15 @@ def _retrieve_roles_page(html_response, session, ssl_verification_enabled, aad_v
     seconds_to_wait = 5
     max_attempts = 12
     counter = 1
+    has_number_matching = False
 
     while True:
         time.sleep(seconds_to_wait)
+
+        number_to_match = _number_matching(html_response)
+        if number_to_match and not has_number_matching:
+            has_number_matching = True
+            click.echo(number_to_match, err=True)
 
         aad_verification_code_text = _aad_verification_code_text(html_response)
         if aad_verification_code_text is not None:
@@ -103,3 +109,8 @@ def _aad_verification_code_text(html_response):
     aad_verification_code_query = './/input[@id="verificationCodeInput"]'
     element = html_response.find(aad_verification_code_query)
     return None if element is None else element.get('placeholder')
+
+def _number_matching(html_response):
+    number_matching_query = './/p[@id="validEntropyNumber"]'
+    element = html_response.find(number_matching_query)
+    return None if element is None else element.text


### PR DESCRIPTION
Solves https://github.com/venth/aws-adfs/issues/371

Add support for number matching in Microsoft Authenticator app, by printing the number found in "validEntropyNumber", if it exists.

![Image](https://github.com/venth/aws-adfs/assets/956651/45ad88db-5b0b-4cc2-a7cf-fc106ea632d1)

Will print in the command line, and when entered, login succeeds.
![Image](https://github.com/venth/aws-adfs/assets/956651/643df775-7ff9-4267-8c93-4b23d57790ec)
