### PR TITLE
Fix for DUO Universal Prompt authentication

### DIFF
--- a/aws_adfs/_duo_universal_prompt_authenticator.py
+++ b/aws_adfs/_duo_universal_prompt_authenticator.py
@@ -145,7 +145,7 @@ def _perform_authentication_transaction(
     ssl_verification_enabled,
 ):
     duo_host = re.sub(
-        r"/frame/frameless/v4/auth.*",
+        r"/frame/frameless/v\d+/auth.*",
         "",
         duo_url,
     )


### PR DESCRIPTION
Changing re.sub in line 147 of this file to look for ANY digit in front of the "v" part. 

We ran into an issue in our environment because the original code here was looking for "v4" and our DUO setup was returning "v3", so this replacement never happened and resulted in a malformed URL leading to 403 responses from the DUO server.