### PR TITLE
feat(login.py): login prompt on stderr if used with stdout flag

### DIFF
--- a/aws_adfs/login.py
+++ b/aws_adfs/login.py
@@ -238,10 +238,10 @@ def login(
                 config.adfs_user, password = _file_user_credentials(config.profile, authfile)
 
             if not config.adfs_user:
-                config.adfs_user = click.prompt(text='Username', type=str, default=config.adfs_user)
+                config.adfs_user = click.prompt(text='Username', type=str, default=config.adfs_user, err=stdout)
 
             if not password:
-                password = click.prompt('Password', type=str, hide_input=True)
+                password = click.prompt('Password', type=str, hide_input=True, err=stdout)
 
             principal_roles, assertion, aws_session_duration = authenticator.authenticate(config, config.adfs_user, password)
 


### PR DESCRIPTION
Prompt "Username" and "Password" login in stderr when using the `--stdout` flag.  

This will ease usage of the JSON output without those world.   i.e. `aws-adfs login ... --stdout > token.json`

Or with AWS external credential process.  
```ini
[profile adfs]
credential_process = sh -c 'aws-adfs login ... --stdout 2> /dev/tty'
```